### PR TITLE
feat: zen mode for the maximized pane

### DIFF
--- a/apps/web/src/components/SplitView.tsx
+++ b/apps/web/src/components/SplitView.tsx
@@ -35,10 +35,12 @@ function edgeFor(rect: DOMRect, x: number, y: number): DropEdge {
 function PaneHeader({
   leaf,
   solo,
+  zen,
   onPointerDown,
 }: {
   leaf: Leaf;
   solo: boolean;
+  zen: boolean;
   onPointerDown: (e: React.PointerEvent) => void;
 }) {
   const renamePane = useStore((s) => s.renamePane);
@@ -111,9 +113,17 @@ function PaneHeader({
         >
           {solo ? <RestoreIcon /> : <MaximizeIcon />}
         </button>
-        <button className="pane-btn" title={withShortcut("Close pane", "closePane")} onClick={() => closePane(leaf.id)}>
-          <CloseIcon />
-        </button>
+        {/* Hidden in zen mode: sitting right next to the restore button, an X
+            reads as "exit zoom" and would silently close the pane instead. */}
+        {!zen && (
+          <button
+            className="pane-btn"
+            title={withShortcut("Close pane", "closePane")}
+            onClick={() => closePane(leaf.id)}
+          >
+            <CloseIcon />
+          </button>
+        )}
       </div>
     </div>
   );
@@ -124,12 +134,15 @@ function PaneSlot({
   leaf,
   showFocus,
   solo,
+  zen = false,
   dropTarget,
   onPaneDragStart,
 }: {
   leaf: Leaf;
   showFocus: boolean;
   solo: boolean;
+  /** Rendered as the floating pane of the zen overlay (hides the close button). */
+  zen?: boolean;
   dropTarget: PaneDropTarget;
   onPaneDragStart: (id: string, e: React.PointerEvent) => void;
 }) {
@@ -147,7 +160,12 @@ function PaneSlot({
       className={`pane-slot ${showFocus && focused ? "focused" : ""}`}
       onMouseDown={() => setFocusedPane(leaf.id)}
     >
-      <PaneHeader leaf={leaf} solo={solo} onPointerDown={(e) => onPaneDragStart(leaf.id, e)} />
+      <PaneHeader
+        leaf={leaf}
+        solo={solo}
+        zen={zen}
+        onPointerDown={(e) => onPaneDragStart(leaf.id, e)}
+      />
       <div className="pane-body">
         {leaf.view === "files" ? (
           <FileTree
@@ -340,6 +358,7 @@ function ZenOverlay({
           leaf={leaf}
           showFocus={false}
           solo
+          zen
           dropTarget={dropTarget}
           onPaneDragStart={onPaneDragStart}
         />

--- a/apps/web/src/components/SplitView.tsx
+++ b/apps/web/src/components/SplitView.tsx
@@ -1,6 +1,8 @@
 import { Fragment, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { beginDragCursor, createDragGhost, endDragCursor } from "../dragGhost";
 import { useI18n } from "../i18n";
+import { registerOccluder, unregisterOccluder } from "../nativeViewOcclusion";
 import { withShortcut } from "../keybindings";
 import { activeHtab, paneCount, useStore, type DropEdge, type HTab, type Pane } from "../state/store";
 import { focusSession } from "../terminal/manager";
@@ -183,18 +185,22 @@ function SplitTree({
   showFocus,
   path,
   dropTarget,
+  ghostId,
   onPaneDragStart,
 }: {
   pane: Pane;
   showFocus: boolean;
   path: number[];
   dropTarget: PaneDropTarget;
+  /** Leaf rendered as an empty placeholder — it's mounted in the zen overlay instead. */
+  ghostId?: string;
   onPaneDragStart: (id: string, e: React.PointerEvent) => void;
 }) {
   const resizeSplit = useStore((s) => s.resizeSplit);
   const containerRef = useRef<HTMLDivElement>(null);
 
   if (pane.kind === "leaf") {
+    if (pane.id === ghostId) return <div className="pane-slot pane-slot-ghost" />;
     return (
       <PaneSlot
         leaf={pane}
@@ -259,6 +265,7 @@ function SplitTree({
               showFocus={showFocus}
               path={[...path, i]}
               dropTarget={dropTarget}
+              ghostId={ghostId}
               onPaneDragStart={onPaneDragStart}
             />
           </div>
@@ -270,6 +277,76 @@ function SplitTree({
 
 function leafKey(pane: Pane): string {
   return pane.kind === "leaf" ? pane.id : pane.children.map(leafKey).join("|");
+}
+
+/**
+ * Zen (maximize) overlay: dimming scrim over the whole app view, with the
+ * zoomed pane floating centered above it. Portaled to <body> so it centers in
+ * the window rather than inside the (sidebar-offset) pane card. Native
+ * webviews in background panes paint over any DOM scrim, so the scrim area is
+ * registered as four occluder bands framing the floating pane — covered web
+ * panes hide themselves while the floating one (whose rect is exactly the
+ * hole) stays visible.
+ */
+function ZenOverlay({
+  htabId,
+  leaf,
+  dropTarget,
+  onPaneDragStart,
+}: {
+  htabId: string;
+  leaf: Leaf;
+  dropTarget: PaneDropTarget;
+  onPaneDragStart: (id: string, e: React.PointerEvent) => void;
+}) {
+  const { t } = useI18n();
+  const toggleMaximize = useStore((s) => s.toggleMaximize);
+  const scrimRef = useRef<HTMLDivElement>(null);
+  const paneRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const scrim = scrimRef.current;
+    const pane = paneRef.current;
+    if (!scrim || !pane) return;
+    const ids = ["top", "bottom", "left", "right"].map((side) => `zen:${htabId}:${side}`);
+    const sync = () => {
+      const r = scrim.getBoundingClientRect();
+      const p = pane.getBoundingClientRect();
+      registerOccluder(ids[0], { x: r.x, y: r.y, width: r.width, height: p.y - r.y });
+      registerOccluder(ids[1], { x: r.x, y: p.bottom, width: r.width, height: r.bottom - p.bottom });
+      registerOccluder(ids[2], { x: r.x, y: p.y, width: p.x - r.x, height: p.height });
+      registerOccluder(ids[3], { x: p.right, y: p.y, width: r.right - p.right, height: p.height });
+    };
+    const ro = new ResizeObserver(sync);
+    ro.observe(scrim);
+    ro.observe(pane);
+    sync();
+    return () => {
+      ro.disconnect();
+      ids.forEach(unregisterOccluder);
+    };
+  }, [htabId]);
+
+  return createPortal(
+    <>
+      <div
+        ref={scrimRef}
+        className="zen-scrim"
+        title={withShortcut(t("pane.zoomedRestore"), "toggleMaximize")}
+        onClick={() => toggleMaximize(leaf.id)}
+      />
+      <div ref={paneRef} className="zen-pane">
+        <PaneSlot
+          leaf={leaf}
+          showFocus={false}
+          solo
+          dropTarget={dropTarget}
+          onPaneDragStart={onPaneDragStart}
+        />
+      </div>
+    </>,
+    document.body,
+  );
 }
 
 /** Top-level: render the magnified pane alone, or the full split tree. */
@@ -406,6 +483,26 @@ export function SplitView({ htab }: { htab: HTab }) {
   };
 
   const maxLeaf = htab.maximized ? findLeaf(htab.layout, htab.maximized) : undefined;
+  if (maxLeaf && paneCount(htab.layout) > 1) {
+    return (
+      <>
+        <SplitTree
+          pane={htab.layout}
+          showFocus={false}
+          path={[]}
+          dropTarget={null}
+          ghostId={maxLeaf.id}
+          onPaneDragStart={startPaneDrag}
+        />
+        <ZenOverlay
+          htabId={htab.id}
+          leaf={maxLeaf}
+          dropTarget={dropTarget}
+          onPaneDragStart={startPaneDrag}
+        />
+      </>
+    );
+  }
   if (maxLeaf) {
     return (
       <PaneSlot

--- a/apps/web/src/i18n.ts
+++ b/apps/web/src/i18n.ts
@@ -66,6 +66,8 @@ const dictionaries: Record<Language, Record<string, string>> = {
     "drag.edge.top": "split top",
     "drag.edge.bottom": "split bottom",
 
+    "pane.zoomedRestore": "Restore split panes",
+
     "kb.title": "KEYBOARD SHORTCUTS",
     "kb.resetAll": "Reset all",
     "kb.reset": "Reset",
@@ -367,6 +369,8 @@ const dictionaries: Record<Language, Record<string, string>> = {
     "drag.edge.right": "拆分到右侧",
     "drag.edge.top": "拆分到上方",
     "drag.edge.bottom": "拆分到下方",
+
+    "pane.zoomedRestore": "还原所有窗格",
 
     "kb.title": "快捷键",
     "kb.resetAll": "全部重置",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1649,6 +1649,47 @@ html.tauri #root {
   flex: 1 1 0;
   min-width: 10px;
 }
+/* Zen (maximize) mode: the split tree stays visible underneath, dimmed by
+   the scrim, and the zoomed pane floats centered above it — so the hidden
+   siblings read as "covered", not "closed". Portaled to <body> and fixed so
+   the pane centers in the whole window, not the sidebar-offset pane card.
+   Clicking the scrim restores the split. Below the ⌘K palette (60) and
+   settings (100) so those still open on top; above everything workspace-level. */
+.zen-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  background: color-mix(in srgb, var(--bg) 62%, transparent);
+  backdrop-filter: blur(3px);
+  cursor: zoom-out;
+  animation: zen-fade-in 140ms ease-out;
+}
+.zen-pane {
+  position: fixed;
+  inset: clamp(16px, 5vh, 48px) clamp(16px, 5vw, 80px);
+  z-index: 31;
+  background: var(--pane-bg, var(--bg));
+  border: 1px solid var(--border);
+  border-radius: var(--pane-radius);
+  overflow: hidden;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.4);
+  animation: zen-pane-in 140ms ease-out;
+}
+/* The zoomed pane's original cell in the dimmed tree — an intentional hole. */
+.pane-slot-ghost {
+  background: transparent;
+}
+@keyframes zen-fade-in {
+  from {
+    opacity: 0;
+  }
+}
+@keyframes zen-pane-in {
+  from {
+    opacity: 0;
+    transform: scale(0.98);
+  }
+}
 .pane-head-title {
   display: block;
   min-width: 0;


### PR DESCRIPTION
## Problem

`Cmd+M` rendered the zoomed pane on its own, so every other pane vanished from the view. The only hint that they still existed was a small Restore icon in the pane header — easy to miss, and the result reads as "this tab only has one pane."

## Approach

Turn it into a Zen mode: the split tree stays mounted and visible underneath, dimmed and blurred by a scrim, with the zoomed pane floating centered above it. The hidden siblings now read as *covered*, not *closed*. Clicking the scrim (or pressing `Cmd+M` again) restores the split.

- The zoomed pane renders as an empty placeholder (`.pane-slot-ghost`) in the underlying tree, so the same terminal session is never mounted twice. Its original cell shows through the scrim as an intentional hole.
- The overlay is portaled to `<body>` and positioned `fixed`, so the pane centers in the whole window rather than in the sidebar-offset `.pane-card`.
- z-index 30/31: above regular content, below the ⌘K palette (60) and settings (100) so those can still open on top.
- Native webviews ignore z-index and paint over any DOM scrim. The scrim area therefore registers four occluder bands framing the floating pane in the existing `nativeViewOcclusion` registry — covered web panes hide themselves, while the floating pane (whose rect is exactly the hole) stays visible. A `ResizeObserver` keeps the bands in sync.
- With only one pane, maximizing still takes the original full-bleed path; no Zen layer.

## Verification

`tsc --noEmit` passes. Verified in the browser against demo mode (`VITE_DEMO=1`): the pane floats centered, the scrim correctly dims the rest of the app view, and clicking the scrim restores the split with terminal contents intact.