### PR TITLE
chore: bump version to 0.1.20

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Termany",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "identifier": "ai.trys.termany",
   "build": {
     "frontendDist": "../../web/dist",

--- a/apps/server/src/acpRuntime.ts
+++ b/apps/server/src/acpRuntime.ts
@@ -181,7 +181,7 @@ class Runtime {
       await connection.agent.request(methods.agent.initialize, {
         protocolVersion: PROTOCOL_VERSION,
         clientCapabilities: {},
-        clientInfo: { name: "Termany", version: "0.1.19" },
+        clientInfo: { name: "Termany", version: "0.1.20" },
       });
       const session = await connection.agent.buildSession(cwd).start();
       runtime = new Runtime(paneId, agent, cwd, child, connection, session);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "termany",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "termany",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "termany",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "private": true,
   "license": "AGPL-3.0-only",
   "description": "Agent-native terminal — local-first, cloud-ready. Workspaces > vertical tabs > horizontal tabs.",


### PR DESCRIPTION
## What changed

- include the newly merged Activity Monitor pane from PR #3
- bump the application, updater, bundled server, and ACP client versions to 0.1.20

## Validation

- `npm -w @termany/web run build`
- server entry bundled with esbuild
- `git diff --check`
