### PR TITLE
feat: add counted agent activity indicators

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch src/index.ts",
-    "start": "tsx src/index.ts"
+    "start": "tsx src/index.ts",
+    "test": "node --import tsx --test src/*.test.ts tests/*.test.ts"
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^1.2.1",

--- a/apps/server/src/agentActivity.ts
+++ b/apps/server/src/agentActivity.ts
@@ -1,0 +1,464 @@
+export type AgentActivityStatus = "working" | "done" | "error";
+
+export interface AgentActivity {
+  status: AgentActivityStatus;
+  agent?: string;
+  updatedAt: number;
+  /** Monotonically increasing task generation for compare-and-set transitions. */
+  taskEpoch: number;
+}
+
+export type AgentActivitySnapshot = Record<string, AgentActivity>;
+
+export interface AgentActivityAcknowledgement {
+  id: string;
+  taskEpoch: number;
+}
+
+interface TrackerOptions {
+  now?: () => number;
+  onChange?: () => void;
+}
+
+interface SessionStreamState {
+  agent?: string;
+  /** True while user input belongs to an agent rather than the returned shell. */
+  agentActive: boolean;
+  /** A register request owns the next Enter, so it must not create a second epoch. */
+  awaitingRegisteredInput: boolean;
+  acknowledgedEpoch?: number;
+  taskEpoch: number;
+  input: string;
+  /** Bounded raw tail used only to recognize a real interactive agent banner. */
+  outputTail: string;
+  pendingOsc: string;
+}
+
+const MAX_INPUT_CHARS = 512;
+const MAX_INPUT_SCAN_CHARS = 8_192;
+const MAX_OUTPUT_TAIL_CHARS = 4_096;
+const MAX_PENDING_OSC_CHARS = 2_048;
+const WORKING_TITLE_RE =
+  /^(?:working|thinking|running|starting|executing|editing|applying|building|testing|installing|searching|reading)(?:[.…]+)?$/i;
+const DONE_TITLE_RE =
+  /^(?:done|ready|idle|waiting|complete|completed|finished)(?:[.…]+)?$/i;
+const ERROR_TITLE_RE =
+  /^(?:error|failed|blocked|action required|needs? input)(?:[.…]+)?$/i;
+
+const BUILTIN_AGENT_COMMANDS: Record<string, string> = {
+  claude: "claude",
+  codex: "codex",
+  cx: "codex",
+  gemini: "gemini",
+  openclaw: "openclaw",
+  fastclaw: "fastclaw",
+  hermes: "hermes",
+  opencode: "opencode",
+  kilo: "kilocode",
+  kilocode: "kilocode",
+  "cursor-agent": "cursor",
+  kimi: "kimi",
+  droid: "droid",
+  omp: "omp",
+};
+
+function cleanAgent(value: unknown): string | undefined {
+  const agent = String(value ?? "").trim().slice(0, 80);
+  return agent || undefined;
+}
+
+function stripTerminalControls(data: string): string {
+  return data
+    .replace(/\x1b\][^\x07]*(?:\x07|\x1b\\)/g, "")
+    .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "")
+    .replace(/\x1b[()][A-Za-z0-9]/g, "")
+    .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "")
+    .replace(/\r\n?/g, "\n");
+}
+
+function statusFromTitle(title: string): AgentActivityStatus | undefined {
+  const fields = title
+    .split(/\s*(?:\||·|•|—|–)\s*/)
+    .map((field) => field.trim())
+    .filter(Boolean);
+  for (let i = fields.length - 1; i >= 0; i--) {
+    if (WORKING_TITLE_RE.test(fields[i])) return "working";
+    if (DONE_TITLE_RE.test(fields[i])) return "done";
+    if (ERROR_TITLE_RE.test(fields[i])) return "error";
+  }
+  return undefined;
+}
+
+function detectedAgent(text: string): string | undefined {
+  if (/\bClaude(?:\s+Code)?\b/i.test(text)) return "claude";
+  if (/\b(?:OpenAI\s+)?Codex(?:\s+CLI)?\b/i.test(text)) return "codex";
+  if (/\bGemini(?:\s+CLI)?\b/i.test(text)) return "gemini";
+  if (/\bOpenClaw\b/i.test(text)) return "openclaw";
+  if (/\bOpenCode\b/i.test(text)) return "opencode";
+  return undefined;
+}
+
+/**
+ * A bare product name can appear in ordinary shell output, documentation, or
+ * even a grep result. These signatures require stable pieces of the real
+ * full-screen startup UI, so aliases such as `cx`/`ccx` can be recognized
+ * without turning `echo "Codex"` into a fake task.
+ */
+function detectedInteractiveAgent(text: string): string | undefined {
+  if (
+    />_\s*OpenAI\s+Codex\s*\(v[^)]+\)[\s\S]{0,1500}\/model\s+to\s+change/i.test(
+      text,
+    )
+  ) {
+    return "codex";
+  }
+  if (
+    /\bClaude\s+Code(?:\s+v[^\s]+)?\b[\s\S]{0,1500}(?:bypass\s+permissions|shift\+tab\s+to\s+cycle)/i.test(
+      text,
+    )
+  ) {
+    return "claude";
+  }
+  return undefined;
+}
+
+/**
+ * A server-owned activity ledger shared by every window. It deliberately has
+ * no time-to-live: silence is not evidence that a task stopped. Raw PTY bytes
+ * may identify an agent or carry an explicit OSC transition, but only the
+ * rendered terminal can reliably identify an idle prompt. Those observations
+ * come back through reportIdle() with the exact task epoch they observed.
+ */
+export class AgentActivityTracker {
+  private readonly activities = new Map<string, AgentActivity>();
+  private readonly streams = new Map<string, SessionStreamState>();
+  private readonly now: () => number;
+  private readonly onChange?: () => void;
+
+  constructor(options: TrackerOptions = {}) {
+    this.now = options.now ?? Date.now;
+    this.onChange = options.onChange;
+  }
+
+  /** Remember a WebSocket's agent hint without claiming that a task started. */
+  bindAgent(id: string, agent?: string): void {
+    const normalizedAgent = cleanAgent(agent);
+    if (!normalizedAgent) return;
+    const stream = this.stream(id);
+    stream.agent = normalizedAgent;
+    const current = this.activities.get(id);
+    if (current && current.agent !== normalizedAgent) {
+      this.setCurrent(id, current.status, current.taskEpoch, normalizedAgent);
+    }
+  }
+
+  /** Registering working is the authoritative start of one new task. */
+  register(
+    id: string,
+    agent?: string,
+    status: AgentActivityStatus = "working",
+  ): void {
+    const normalizedAgent = cleanAgent(agent);
+    const stream = this.stream(id);
+    if (normalizedAgent) stream.agent = normalizedAgent;
+    if (status === "working") {
+      this.startTask(id, stream.agent, true);
+      return;
+    }
+    if (!this.activities.has(id)) this.startTask(id, stream.agent, false);
+    this.setCurrent(id, status, stream.taskEpoch, stream.agent);
+  }
+
+  noteInput(id: string, data: string, agent?: string): void {
+    const stream = this.stream(id);
+    const normalizedAgent = cleanAgent(agent);
+    if (normalizedAgent) stream.agent = normalizedAgent;
+
+    const scanned = data.slice(0, MAX_INPUT_SCAN_CHARS);
+    for (let index = 0; index < scanned.length; index++) {
+      const char = scanned[index];
+      if (char === "\r") {
+        this.submitInput(id, stream);
+      } else if (char === "\x03" || char === "\x15") {
+        stream.input = "";
+      } else if (char === "\x08" || char === "\x7f") {
+        stream.input = stream.input.slice(0, -1);
+      } else if (char >= " " && char !== "\x7f") {
+        stream.input = (stream.input + char).slice(-MAX_INPUT_CHARS);
+      }
+    }
+
+    // A hostile or accidental giant paste must not make the event loop scan
+    // megabytes character-by-character. Preserve the only transition that can
+    // matter outside the bounded prefix: an Enter submitted to an active agent.
+    if (data.length > scanned.length && data.indexOf("\r", scanned.length) >= 0) {
+      stream.input = "";
+      if (stream.agentActive) this.submitInput(id, stream);
+    }
+  }
+
+  noteOutput(id: string, data: string): void {
+    const stream = this.stream(id);
+    const { plain, osc } = this.extractOsc(stream, data);
+
+    for (const payload of osc) {
+      const activity = /^778;(working|done|error)(?:;([^\r\n]*))?$/i.exec(
+        payload,
+      );
+      if (activity) {
+        const status = activity[1].toLowerCase() as AgentActivityStatus;
+        const agent = cleanAgent(activity[2]) ?? stream.agent;
+        if (agent) stream.agent = agent;
+        this.applyOutputTransition(id, status, agent);
+        continue;
+      }
+      const title = /^(?:0|2);([\s\S]*)$/.exec(payload)?.[1];
+      if (title === undefined) continue;
+      const agent = detectedAgent(title);
+      if (agent) stream.agent = agent;
+      const status = statusFromTitle(title);
+      if (status && (this.activities.has(id) || stream.agent)) {
+        this.applyOutputTransition(id, status, stream.agent);
+      }
+    }
+
+    stream.outputTail = (stream.outputTail + plain).slice(-MAX_OUTPUT_TAIL_CHARS);
+    const text = stripTerminalControls(stream.outputTail);
+    const interactiveAgent = detectedInteractiveAgent(text);
+    if (interactiveAgent) {
+      stream.agent = interactiveAgent;
+      if (!stream.agentActive && this.activities.get(id)?.status !== "working") {
+        this.startTask(id, interactiveAgent, false);
+      }
+      return;
+    }
+
+    const agent = detectedAgent(text);
+    // A banner can improve the label, but arbitrary shell output mentioning
+    // "Codex" or "Claude" is not proof that an agent task started.
+    if (agent && !stream.agent) stream.agent = agent;
+  }
+
+  /** Apply a rendered-screen idle observation only to the task it observed. */
+  reportIdle(id: string, taskEpoch: number, agentActive: boolean): boolean {
+    const current = this.activities.get(id);
+    if (!current || current.taskEpoch !== taskEpoch) return false;
+    const stream = this.stream(id);
+    if (stream.taskEpoch !== taskEpoch) return false;
+    stream.agentActive = agentActive;
+    stream.awaitingRegisteredInput = false;
+    if (!agentActive) {
+      stream.agent = undefined;
+      stream.outputTail = "";
+    }
+    if (current.status !== "working") return current.status === "done";
+    this.setCurrent(id, "done", taskEpoch, current.agent ?? stream.agent);
+    return true;
+  }
+
+  /** Mark an exact in-flight task as blocked on a user decision or input. */
+  reportBlocked(id: string, taskEpoch: number): boolean {
+    const current = this.activities.get(id);
+    if (!current || current.taskEpoch !== taskEpoch) return false;
+    const stream = this.stream(id);
+    if (stream.taskEpoch !== taskEpoch) return false;
+    stream.agentActive = true;
+    stream.awaitingRegisteredInput = false;
+    if (current.status !== "working") return current.status === "error";
+    this.setCurrent(id, "error", taskEpoch, current.agent ?? stream.agent);
+    return true;
+  }
+
+  noteExit(id: string, exitCode: number, signal?: number): void {
+    const current = this.activities.get(id);
+    if (!current) return;
+    const stream = this.stream(id);
+    stream.agentActive = false;
+    stream.awaitingRegisteredInput = false;
+    this.setCurrent(
+      id,
+      exitCode === 0 && !signal ? "done" : "error",
+      current.taskEpoch,
+      current.agent,
+    );
+  }
+
+  /** Clear green only when the client acknowledges that exact task generation. */
+  acknowledge(items: AgentActivityAcknowledgement[]): void {
+    let changed = false;
+    for (const { id, taskEpoch } of items) {
+      const current = this.activities.get(id);
+      if (current?.status !== "done" || current.taskEpoch !== taskEpoch) continue;
+      this.activities.delete(id);
+      this.stream(id).acknowledgedEpoch = taskEpoch;
+      changed = true;
+    }
+    if (changed) this.onChange?.();
+  }
+
+  remove(id: string): void {
+    const changed = this.activities.delete(id);
+    this.streams.delete(id);
+    if (changed) this.onChange?.();
+  }
+
+  snapshot(): AgentActivitySnapshot {
+    return Object.fromEntries(
+      [...this.activities.entries()].map(([id, activity]) => [
+        id,
+        { ...activity },
+      ]),
+    );
+  }
+
+  private stream(id: string): SessionStreamState {
+    let stream = this.streams.get(id);
+    if (!stream) {
+      stream = {
+        agentActive: false,
+        awaitingRegisteredInput: false,
+        taskEpoch: 0,
+        input: "",
+        outputTail: "",
+        pendingOsc: "",
+      };
+      this.streams.set(id, stream);
+    }
+    return stream;
+  }
+
+  private submitInput(id: string, stream: SessionStreamState): void {
+    const command = stream.input.trim().split(/\s+/, 1)[0]?.toLowerCase();
+    const detected = command ? BUILTIN_AGENT_COMMANDS[command] : undefined;
+    stream.input = "";
+    if (detected) {
+      stream.agent = detected;
+      stream.agentActive = true;
+    }
+    if (!detected && !stream.agentActive) return;
+    if (
+      stream.awaitingRegisteredInput &&
+      this.activities.get(id)?.status === "working"
+    ) {
+      stream.awaitingRegisteredInput = false;
+      return;
+    }
+    this.startTask(id, stream.agent, false);
+  }
+
+  private startTask(
+    id: string,
+    agent?: string,
+    awaitingRegisteredInput = false,
+  ): void {
+    const stream = this.stream(id);
+    stream.taskEpoch =
+      stream.taskEpoch >= Number.MAX_SAFE_INTEGER ? 1 : stream.taskEpoch + 1;
+    stream.agentActive = true;
+    stream.awaitingRegisteredInput = awaitingRegisteredInput;
+    stream.input = "";
+    this.setCurrent(
+      id,
+      "working",
+      stream.taskEpoch,
+      cleanAgent(agent) ?? stream.agent,
+    );
+  }
+
+  private applyOutputTransition(
+    id: string,
+    status: AgentActivityStatus,
+    agent?: string,
+  ): void {
+    const stream = this.stream(id);
+    if (status === "working") {
+      stream.agentActive = true;
+      stream.awaitingRegisteredInput = false;
+      const current = this.activities.get(id);
+      if (!current || current.status !== "working") {
+        this.startTask(id, agent, false);
+      } else {
+        this.setCurrent(id, "working", current.taskEpoch, agent);
+      }
+      return;
+    }
+    const current = this.activities.get(id);
+    if (!current) return;
+    stream.awaitingRegisteredInput = false;
+    this.setCurrent(id, status, current.taskEpoch, agent ?? current.agent);
+  }
+
+  private setCurrent(
+    id: string,
+    status: AgentActivityStatus,
+    taskEpoch: number,
+    agent?: string,
+  ): void {
+    const previous = this.activities.get(id);
+    const normalizedAgent = cleanAgent(agent) ?? previous?.agent;
+    if (
+      previous?.status === status &&
+      previous.agent === normalizedAgent &&
+      previous.taskEpoch === taskEpoch
+    ) {
+      return;
+    }
+    this.activities.set(id, {
+      status,
+      agent: normalizedAgent,
+      updatedAt: this.now(),
+      taskEpoch,
+    });
+    this.onChange?.();
+  }
+
+  private extractOsc(
+    stream: SessionStreamState,
+    chunk: string,
+  ): { plain: string; osc: string[] } {
+    const input = stream.pendingOsc + chunk;
+    stream.pendingOsc = "";
+    const osc: string[] = [];
+    let plain = "";
+    let cursor = 0;
+
+    while (cursor < input.length) {
+      const start = input.indexOf("\x1b]", cursor);
+      if (start < 0) {
+        const tail = input.slice(cursor);
+        if (tail.endsWith("\x1b")) {
+          plain += tail.slice(0, -1);
+          stream.pendingOsc = "\x1b";
+        } else {
+          plain += tail;
+        }
+        break;
+      }
+      plain += input.slice(cursor, start);
+      const bell = input.indexOf("\x07", start + 2);
+      const st = input.indexOf("\x1b\\", start + 2);
+      const end = bell < 0 ? st : st < 0 ? bell : Math.min(bell, st);
+      const nested = input.indexOf("\x1b]", start + 2);
+      if (end < 0) {
+        if (input.length - start <= MAX_PENDING_OSC_CHARS) {
+          stream.pendingOsc = input.slice(start);
+        } else if (nested >= 0) {
+          cursor = nested;
+          continue;
+        }
+        break;
+      }
+      if (end - start > MAX_PENDING_OSC_CHARS) {
+        cursor =
+          nested >= 0 && nested < end
+            ? nested
+            : end + (input.startsWith("\x1b\\", end) ? 2 : 1);
+        continue;
+      }
+      osc.push(input.slice(start + 2, end));
+      cursor = end + (input.startsWith("\x1b\\", end) ? 2 : 1);
+    }
+
+    return { plain, osc };
+  }
+}

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -7,10 +7,11 @@ setGlobalDispatcher(new EnvHttpProxyAgent());
 import { spawn } from "node-pty";
 import { execFile } from "node:child_process";
 import fs from "node:fs";
-import { createServer } from "node:http";
+import { createServer, type ServerResponse } from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
+import { AgentActivityTracker } from "./agentActivity.js";
 import { listAgentSessions, listAgentUsage, warmAgentSessionCache } from "./agentSessions.js";
 import { streamAgentChat } from "./agentChat.js";
 import { listAgentConfigs, saveAgentConfigs } from "./agentConfig.js";
@@ -384,6 +385,44 @@ const ptySessions = new Map<string, PtySession>();
 // always sends one) get no restore/reattach semantics: killed on disconnect,
 // same as every session used to behave before reattach existed.
 const ephemeralSessions = new Set<PtySession>();
+const activityStreams = new Set<ServerResponse>();
+const activityInstance = `${process.pid}-${Date.now().toString(36)}`;
+let activityRevision = 0;
+const activityTracker = new AgentActivityTracker({ onChange: activityChanged });
+
+function activityPayload() {
+  return {
+    instance: activityInstance,
+    revision: activityRevision,
+    activities: activityTracker.snapshot(),
+  };
+}
+
+function activityEvent(): string {
+  return `event: activity\ndata: ${JSON.stringify(activityPayload())}\n\n`;
+}
+
+function activityChanged(): void {
+  activityRevision++;
+  const event = activityEvent();
+  for (const stream of activityStreams) {
+    try {
+      stream.write(event);
+    } catch {
+      activityStreams.delete(stream);
+    }
+  }
+}
+
+setInterval(() => {
+  for (const stream of activityStreams) {
+    try {
+      stream.write(": keepalive\n\n");
+    } catch {
+      activityStreams.delete(stream);
+    }
+  }
+}, 20_000).unref();
 
 function isOpen(ws: WebSocket | null): ws is WebSocket {
   return !!ws && ws.readyState === ws.OPEN;
@@ -394,6 +433,7 @@ function wireSession(id: string | undefined, session: PtySession): void {
   session.pty.onData((data) => {
     if (isOpen(session.ws)) session.ws.send(data);
     ringAppend(session.ring, data);
+    if (id) activityTracker.noteOutput(id, data);
     if (IS_WIN) trackOscCwd(session.pty.pid, data);
   });
   session.pty.onExit(({ exitCode, signal }) => {
@@ -413,6 +453,7 @@ function wireSession(id: string | undefined, session: PtySession): void {
       session.ws.close();
     }
     if (id) {
+      activityTracker.noteExit(id, exitCode, signal);
       // Natural exit — flush final history so it still restores as plain
       // scrollback (cwd/history stay in the DB; only /api/forget wipes them).
       if (session.ring.dirty) {
@@ -431,6 +472,7 @@ function wireSession(id: string | undefined, session: PtySession): void {
 
 /** Kill a session's live process (if any), preserving its restore history. */
 function killSession(id: string): void {
+  activityTracker.remove(id);
   const session = ptySessions.get(id);
   if (!session) return;
   if (session.ring.dirty) {
@@ -507,6 +549,108 @@ const http = createServer((req, res) => {
     json(500, { error: msg });
   };
   const reqUrl = new URL(req.url ?? "/", "http://localhost");
+
+  // Agent activity is server-owned so every app window reads the same state.
+  // SSE pushes complete snapshots, making reconnects self-healing instead of
+  // relying on a fragile sequence of individual transitions.
+  if (req.method === "GET" && reqUrl.pathname === "/api/activity") {
+    json(200, activityPayload());
+    return;
+  }
+  if (req.method === "GET" && reqUrl.pathname === "/api/activity/events") {
+    res.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+    });
+    activityStreams.add(res);
+    res.write("retry: 1000\n");
+    res.write(activityEvent());
+    res.on("close", () => activityStreams.delete(res));
+    res.on("error", () => activityStreams.delete(res));
+    return;
+  }
+  if (req.method === "POST" && reqUrl.pathname === "/api/activity/register") {
+    readJson(req)
+      .then((body) => {
+        const id = typeof body?.id === "string" ? body.id.trim() : "";
+        if (!id || id.length > 256) {
+          json(400, { error: "session id is required" });
+          return;
+        }
+        // Completion is accepted only through the epoch-checked report route.
+        activityTracker.register(
+          id,
+          body?.agent ? String(body.agent) : undefined,
+          "working",
+        );
+        json(200, { ok: true, ...activityPayload() });
+      })
+      .catch(fail);
+    return;
+  }
+  if (req.method === "POST" && reqUrl.pathname === "/api/activity/ack") {
+    readJson(req)
+      .then((body) => {
+        const items = Array.isArray(body?.items)
+          ? body.items
+              .slice(0, 1_000)
+              .map((item: unknown) => {
+                if (!item || typeof item !== "object") return null;
+                const raw = item as Record<string, unknown>;
+                const id = typeof raw.id === "string" ? raw.id.trim() : "";
+                const taskEpoch = Number(raw.taskEpoch);
+                if (
+                  !id ||
+                  id.length > 256 ||
+                  !Number.isSafeInteger(taskEpoch) ||
+                  taskEpoch <= 0
+                ) {
+                  return null;
+                }
+                return { id, taskEpoch };
+              })
+              .filter(
+                (
+                  item,
+                ): item is { id: string; taskEpoch: number } => item !== null,
+              )
+          : [];
+        activityTracker.acknowledge(items);
+        json(200, { ok: true, ...activityPayload() });
+      })
+      .catch(fail);
+    return;
+  }
+  if (req.method === "POST" && reqUrl.pathname === "/api/activity/report") {
+    readJson(req)
+      .then((body) => {
+        const id = typeof body?.id === "string" ? body.id.trim() : "";
+        const taskEpoch = Number(body?.taskEpoch);
+        const status = body?.status === undefined ? "done" : body.status;
+        if (
+          !id ||
+          id.length > 256 ||
+          !Number.isSafeInteger(taskEpoch) ||
+          taskEpoch <= 0 ||
+          (status !== "done" && status !== "error") ||
+          typeof body?.agentActive !== "boolean"
+        ) {
+          json(400, {
+            error: "valid session id, task epoch, and agent state are required",
+          });
+          return;
+        }
+        if (status === "error") {
+          activityTracker.reportBlocked(id, taskEpoch);
+        } else {
+          activityTracker.reportIdle(id, taskEpoch, body.agentActive);
+        }
+        json(200, { ok: true, ...activityPayload() });
+      })
+      .catch(fail);
+    return;
+  }
 
   // Model-provider settings (keys stored server-side, masked on read).
   if (req.method === "GET" && req.url === "/api/models") {
@@ -1302,12 +1446,14 @@ wss.on("connection", async (ws: WebSocket, req) => {
   const url = new URL(req.url ?? "/", "ws://localhost");
   const sessionId = url.searchParams.get("session");
   const sshTarget = url.searchParams.get("ssh");
+  const agent = url.searchParams.get("agent") ?? undefined;
 
   // --- Reattach: the session's shell is still running (detached or stolen
   // from a stale connection) — resume it instead of spawning a fresh one.
   const existing = sessionId ? ptySessions.get(sessionId) : undefined;
   if (existing && existing.sshTarget === sshTarget) {
     console.log(`[termany] client #${cid} reattached to session ${sessionId} (pid ${existing.pty.pid})`);
+    activityTracker.bindAgent(sessionId!, agent);
     if (existing.ws && existing.ws !== ws) {
       try {
         existing.ws.close();
@@ -1325,7 +1471,10 @@ wss.on("connection", async (ws: WebSocket, req) => {
       } catch {
         return;
       }
-      if (msg.type === "input") existing.pty.write(msg.data);
+      if (msg.type === "input") {
+        activityTracker.noteInput(sessionId!, msg.data, agent);
+        existing.pty.write(msg.data);
+      }
       else if (msg.type === "resize") {
         try {
           existing.pty.resize(Math.max(1, msg.cols), Math.max(1, msg.rows));
@@ -1369,6 +1518,7 @@ wss.on("connection", async (ws: WebSocket, req) => {
       return;
     }
     if (msg.type === "input") {
+      if (sessionId) activityTracker.noteInput(sessionId, msg.data, agent);
       session.pty.write(msg.data);
     } else if (msg.type === "resize") {
       try {
@@ -1463,6 +1613,7 @@ wss.on("connection", async (ws: WebSocket, req) => {
   };
   if (sessionId) ptySessions.set(sessionId, session);
   else ephemeralSessions.add(session);
+  if (sessionId) activityTracker.bindAgent(sessionId, agent);
   wireSession(sessionId ?? undefined, session);
 
   pendingMessages.splice(0).forEach(applyClientMessage);

--- a/apps/server/tests/agentActivity.test.ts
+++ b/apps/server/tests/agentActivity.test.ts
@@ -1,0 +1,212 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { AgentActivityTracker } from "../src/agentActivity.ts";
+
+test("keeps a silent task working until a real transition arrives", () => {
+  let now = 1_000;
+  const tracker = new AgentActivityTracker({ now: () => now });
+
+  tracker.register("pane-a", "openclaw");
+  now += 60 * 60 * 1_000;
+  tracker.noteOutput("pane-a", "still quiet");
+
+  assert.deepEqual(tracker.snapshot(), {
+    "pane-a": {
+      status: "working",
+      agent: "openclaw",
+      updatedAt: 1_000,
+      taskEpoch: 1,
+    },
+  });
+});
+
+test("ordinary output mentioning an error does not turn a task red", () => {
+  const tracker = new AgentActivityTracker();
+  tracker.register("pane-a", "codex");
+
+  tracker.noteOutput(
+    "pane-a",
+    "Fixed the error successfully. No errors remain.\r\n",
+  );
+
+  assert.equal(tracker.snapshot()["pane-a"]?.status, "working");
+});
+
+test("explicit idle titles finish a task and acknowledgement clears only green", () => {
+  const tracker = new AgentActivityTracker();
+  tracker.register("done-pane", "claude");
+  tracker.register("error-pane", "codex", "error");
+
+  tracker.noteOutput("done-pane", "\x1b]2;Claude Code | Ready\x07");
+  assert.equal(tracker.snapshot()["done-pane"]?.status, "done");
+
+  tracker.acknowledge([
+    { id: "done-pane", taskEpoch: 1 },
+    { id: "error-pane", taskEpoch: 1 },
+  ]);
+  assert.equal(tracker.snapshot()["done-pane"], undefined);
+  assert.equal(tracker.snapshot()["error-pane"]?.status, "error");
+});
+
+test("chunked OSC signals rotate red back through yellow on retry", () => {
+  let now = 5_000;
+  const tracker = new AgentActivityTracker({ now: () => now });
+  tracker.register("pane-a", "custom-agent");
+
+  tracker.noteOutput("pane-a", "\x1b]778;err");
+  now += 1;
+  tracker.noteOutput("pane-a", "or\x07");
+  assert.deepEqual(tracker.snapshot()["pane-a"], {
+    status: "error",
+    agent: "custom-agent",
+    updatedAt: 5_001,
+    taskEpoch: 1,
+  });
+
+  tracker.noteInput("pane-a", "retry\r");
+  assert.equal(tracker.snapshot()["pane-a"]?.status, "working");
+  assert.equal(tracker.snapshot()["pane-a"]?.taskEpoch, 2);
+});
+
+test("raw prompts and alternate-screen exits never complete a task", () => {
+  const output = [
+    "\x1b[?1049l",
+    "\r\n> ",
+    "\r\nuser@host project % ",
+    "\r\n### final answer\r\n",
+  ].join("");
+
+  for (const width of [1, 2, 7, 4_096]) {
+    const tracker = new AgentActivityTracker();
+    tracker.register("pane-a", "codex");
+    for (let offset = 0; offset < output.length; offset += width) {
+      tracker.noteOutput("pane-a", output.slice(offset, offset + width));
+    }
+    assert.equal(
+      tracker.snapshot()["pane-a"]?.status,
+      "working",
+      `chunk width ${width}`,
+    );
+  }
+});
+
+test("rendered reports use task epochs as compare-and-set tokens", () => {
+  const tracker = new AgentActivityTracker();
+  tracker.register("pane-a", "codex");
+
+  assert.equal(tracker.reportIdle("pane-a", 99, true), false);
+  assert.equal(tracker.reportIdle("pane-a", 1, true), true);
+  assert.equal(tracker.snapshot()["pane-a"]?.status, "done");
+
+  tracker.noteInput("pane-a", "follow up\r");
+  assert.equal(tracker.snapshot()["pane-a"]?.taskEpoch, 2);
+  assert.equal(tracker.reportBlocked("pane-a", 1), false);
+  assert.equal(tracker.snapshot()["pane-a"]?.status, "working");
+});
+
+test("confirmation reports turn the exact working task red", () => {
+  const tracker = new AgentActivityTracker();
+  tracker.register("pane-a", "codex");
+
+  assert.equal(tracker.reportBlocked("pane-a", 99), false);
+  assert.equal(tracker.reportBlocked("pane-a", 1), true);
+  assert.equal(tracker.snapshot()["pane-a"]?.status, "error");
+
+  tracker.noteInput("pane-a", "yes\r");
+  assert.equal(tracker.snapshot()["pane-a"]?.status, "working");
+  assert.equal(tracker.snapshot()["pane-a"]?.taskEpoch, 2);
+});
+
+test("green and red each rotate through a new yellow epoch", () => {
+  const tracker = new AgentActivityTracker();
+  tracker.register("pane-a", "codex");
+  tracker.reportIdle("pane-a", 1, true);
+  tracker.acknowledge([{ id: "pane-a", taskEpoch: 1 }]);
+
+  tracker.register("pane-a", "codex");
+  tracker.noteInput("pane-a", "follow up\r");
+  assert.equal(tracker.snapshot()["pane-a"]?.status, "working");
+  assert.equal(tracker.snapshot()["pane-a"]?.taskEpoch, 2);
+
+  tracker.reportBlocked("pane-a", 2);
+  tracker.register("pane-a", "codex");
+  tracker.noteInput("pane-a", "yes\r");
+  assert.equal(tracker.snapshot()["pane-a"]?.status, "working");
+  assert.equal(tracker.snapshot()["pane-a"]?.taskEpoch, 3);
+});
+
+test("a stale acknowledgement cannot clear a newer completed task", () => {
+  const tracker = new AgentActivityTracker();
+  tracker.register("pane-a", "claude");
+  tracker.reportIdle("pane-a", 1, true);
+  tracker.noteInput("pane-a", "next\r");
+  tracker.reportIdle("pane-a", 2, true);
+
+  tracker.acknowledge([{ id: "pane-a", taskEpoch: 1 }]);
+  assert.equal(tracker.snapshot()["pane-a"]?.taskEpoch, 2);
+  tracker.acknowledge([{ id: "pane-a", taskEpoch: 2 }]);
+  assert.equal(tracker.snapshot()["pane-a"], undefined);
+});
+
+test("returning to a shell removes sticky agent identity", () => {
+  const tracker = new AgentActivityTracker();
+  tracker.register("pane-a", "codex");
+  tracker.reportIdle("pane-a", 1, false);
+  tracker.acknowledge([{ id: "pane-a", taskEpoch: 1 }]);
+
+  tracker.noteInput("pane-a", "ls\r");
+  assert.equal(tracker.snapshot()["pane-a"], undefined);
+
+  tracker.noteInput("pane-a", "codex\r");
+  assert.equal(tracker.snapshot()["pane-a"]?.status, "working");
+  assert.equal(tracker.snapshot()["pane-a"]?.taskEpoch, 2);
+});
+
+test("agent hints do not claim that work started", () => {
+  const tracker = new AgentActivityTracker();
+  tracker.bindAgent("pane-a", "custom-agent");
+  tracker.noteInput("pane-a", "pwd\r");
+  assert.deepEqual(tracker.snapshot(), {});
+});
+
+test("cx and aliased interactive banners bootstrap activity", () => {
+  const direct = new AgentActivityTracker();
+  direct.noteInput("pane-a", "cx\r");
+  assert.equal(direct.snapshot()["pane-a"]?.agent, "codex");
+
+  const aliased = new AgentActivityTracker();
+  aliased.noteInput("pane-b", "ccx\r");
+  assert.deepEqual(aliased.snapshot(), {});
+  const banner = [
+    "╭────────────────────────────────────────────╮\r\n",
+    "│ >_ OpenAI Codex (v0.144.6)                │\r\n",
+    "│ model: gpt-5.6-sol xhigh /model to change │\r\n",
+    "╰────────────────────────────────────────────╯\r\n",
+  ].join("");
+  for (let offset = 0; offset < banner.length; offset += 17) {
+    aliased.noteOutput("pane-b", banner.slice(offset, offset + 17));
+  }
+  assert.equal(aliased.snapshot()["pane-b"]?.status, "working");
+  assert.equal(aliased.snapshot()["pane-b"]?.agent, "codex");
+});
+
+test("malformed OSC cannot swallow a later activity signal", () => {
+  const tracker = new AgentActivityTracker();
+  tracker.register("pane-a", "codex");
+  tracker.noteOutput("pane-a", `\x1b]${"x".repeat(3_000)}`);
+  tracker.noteOutput("pane-a", "\x1b]778;error\x07");
+  assert.equal(tracker.snapshot()["pane-a"]?.status, "error");
+});
+
+test("server wires the shared tracker through PTY input, output, and APIs", () => {
+  const server = readFileSync(new URL("../src/index.ts", import.meta.url), "utf8");
+
+  assert.match(server, /new AgentActivityTracker/);
+  assert.match(server, /activityTracker\.noteInput/);
+  assert.match(server, /activityTracker\.noteOutput/);
+  assert.match(server, /\/api\/activity\/events/);
+  assert.match(server, /\/api\/activity\/register/);
+  assert.match(server, /\/api\/activity\/ack/);
+  assert.match(server, /\/api\/activity\/report/);
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
     "build:demo": "tsc --noEmit && VITE_DEMO=1 vite build --base=/demo/ --outDir dist-demo",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node --import tsx --test tests/*.test.ts src/*.test.ts src/terminal/*.test.ts src/terminal/*.test.mjs"
   },
   "dependencies": {
     "@codemirror/language-data": "^6.5.1",

--- a/apps/web/src/components/HTabBar.tsx
+++ b/apps/web/src/components/HTabBar.tsx
@@ -6,10 +6,12 @@ import { useI18n } from "../i18n";
 import { withShortcut } from "../keybindings";
 import { useStore, activeNode, type Pane } from "../state/store";
 import {
-  aggregateAgentActivity,
+  acknowledgeAgentActivities,
+  agentActivitySummary,
   agentActivitySnapshot,
   agentActivityTitle,
   subscribeAgentActivity,
+  type AgentActivityStatus,
 } from "../terminal/manager";
 import { ChevronIcon, CloseIcon, PanelIcon, PanelRightIcon, PlusIcon } from "./icons";
 
@@ -21,6 +23,8 @@ import { ChevronIcon, CloseIcon, PanelIcon, PanelRightIcon, PlusIcon } from "./i
 function leafIds(pane: Pane): string[] {
   return pane.kind === "leaf" ? [pane.id] : pane.children.flatMap(leafIds);
 }
+
+const ACTIVITY_STATUSES = ["working", "done", "error"] as const;
 
 export function HTabBar() {
   const { t } = useI18n();
@@ -172,7 +176,8 @@ export function HTabBar() {
       <div className="htab-strip" ref={stripRef} data-tauri-drag-region>
       {node?.htabs.map((h) => (
         (() => {
-          const activity = aggregateAgentActivity(leafIds(h.layout));
+          const ids = leafIds(h.layout);
+          const activity = agentActivitySummary(ids);
           return (
             <div
               key={h.id}
@@ -185,17 +190,30 @@ export function HTabBar() {
                   return;
                 }
                 setActiveHTab(h.id);
+                acknowledgeAgentActivities(ids);
               }}
               onDoubleClick={() => setEditing(h.id)}
               onPointerDown={(e) => startTabDrag(h.id, e)}
             >
-              {activity && (
-                <span
-                  className={`agent-dot ${activity.status}`}
-                  title={agentActivityTitle(activity)}
-                  aria-label={agentActivityTitle(activity)}
-                />
-              )}
+              {ACTIVITY_STATUSES.map((status: AgentActivityStatus) => {
+                const count = activity[status];
+                if (!count) return null;
+                const label = `${agentActivityTitle({
+                  status,
+                  updatedAt: 0,
+                })} (${count})`;
+                return (
+                  <span
+                    key={status}
+                    className="tree-count activity-count"
+                    title={label}
+                    aria-label={label}
+                  >
+                    <span className={`agent-dot ${status}`} />
+                    {count}
+                  </span>
+                );
+              })}
               {editing === h.id ? (
                 <input
                   className="htab-rename"

--- a/apps/web/src/components/SplitView.tsx
+++ b/apps/web/src/components/SplitView.tsx
@@ -1,11 +1,18 @@
-import { Fragment, useEffect, useId, useRef, useState } from "react";
+import { Fragment, useEffect, useId, useRef, useState, useSyncExternalStore } from "react";
 import { createPortal } from "react-dom";
 import { beginDragCursor, createDragGhost, endDragCursor } from "../dragGhost";
 import { useI18n } from "../i18n";
 import { registerOccluder, unregisterOccluder } from "../nativeViewOcclusion";
 import { withShortcut } from "../keybindings";
 import { activeHtab, paneCount, useStore, type DropEdge, type HTab, type Pane } from "../state/store";
-import { focusSession } from "../terminal/manager";
+import {
+  acknowledgeAgentActivities,
+  aggregateAgentActivity,
+  agentActivitySnapshot,
+  agentActivityTitle,
+  focusSession,
+  subscribeAgentActivity,
+} from "../terminal/manager";
 import { FileTree } from "./FileTree";
 import { GitDiffView } from "./GitDiffView";
 import {
@@ -149,6 +156,12 @@ function PaneHeader({
   const toggleMaximize = useStore((s) => s.toggleMaximize);
   const [editing, setEditing] = useState(false);
   const renameWidth = `${Math.max(8, leaf.title.length + 1)}ch`;
+  useSyncExternalStore(
+    subscribeAgentActivity,
+    () => agentActivitySnapshot([leaf.id]),
+    () => "",
+  );
+  const activity = aggregateAgentActivity([leaf.id]);
 
   // Double-clicking the header zooms the pane, same as the maximize button —
   // but not while renaming, and not when the dblclick lands on the title
@@ -165,6 +178,13 @@ function PaneHeader({
       onPointerDown={editing ? undefined : onPointerDown}
       onDoubleClick={onHeaderDoubleClick}
     >
+      {activity && (
+        <span
+          className={`agent-dot ${activity.status}`}
+          title={agentActivityTitle(activity)}
+          aria-label={agentActivityTitle(activity)}
+        />
+      )}
       <span className="pane-head-name">
         {(leaf.view ?? "terminal") === "terminal" ? (
           <SshConnections
@@ -245,14 +265,20 @@ function PaneSlot({
   const dropEdge = dropTarget?.id === leaf.id ? dropTarget.edge : null;
 
   useEffect(() => {
-    if (focused) focusSession(leaf.id);
+    if (focused) {
+      focusSession(leaf.id);
+      acknowledgeAgentActivities([leaf.id]);
+    }
   }, [focused, leaf.id]);
 
   return (
     <div
       data-pane-id={leaf.id}
       className={`pane-slot ${showFocus && focused ? "focused" : ""}`}
-      onMouseDown={() => setFocusedPane(leaf.id)}
+      onMouseDown={() => {
+        setFocusedPane(leaf.id);
+        acknowledgeAgentActivities([leaf.id]);
+      }}
     >
       <PaneHeader
         leaf={leaf}

--- a/apps/web/src/components/TreeSidebar.tsx
+++ b/apps/web/src/components/TreeSidebar.tsx
@@ -4,15 +4,18 @@ import { useI18n } from "../i18n";
 import { withShortcut } from "../keybindings";
 import { activeWorkspace, HTAB_DRAG_MIME, useStore, type TreeNode } from "../state/store";
 import {
-  aggregateAgentActivity,
+  acknowledgeAgentActivities,
+  agentActivitySummary,
   agentActivitySnapshot,
   agentActivityTitle,
   subscribeAgentActivity,
+  type AgentActivityStatus,
 } from "../terminal/manager";
 import { ChevronIcon, CloseIcon, CollapseAllIcon, PageIcon, PlusIcon } from "./icons";
 import { WorkspaceSwitcher } from "./WorkspaceSwitcher";
 
 const DRAG_MIME = "application/x-termany-node";
+const ACTIVITY_STATUSES = ["working", "done", "error"] as const;
 type TreeDropPos = "into" | "before" | "after";
 type NodeDragUi = { id: string; targetId: string | null; pos: TreeDropPos | null; overTree: boolean };
 
@@ -58,7 +61,11 @@ function TreeItem({
   const activeDropPos = pointerDropPos ?? dropPos;
 
   const hasChildren = node.children.length > 0;
-  const activity = aggregateAgentActivity(subtreeLeafIds(node));
+  const allLeafIds = subtreeLeafIds(node);
+  const viewedLeafIds = node.htabs
+    .filter((tab) => tab.id === node.activeHTab)
+    .flatMap((tab) => paneLeafIds(tab.layout));
+  const activity = agentActivitySummary(allLeafIds);
 
   return (
     <>
@@ -77,6 +84,7 @@ function TreeItem({
             return;
           }
           setActiveNode(node.id);
+          acknowledgeAgentActivities(viewedLeafIds);
         }}
         onPointerDown={(e) => {
           if (!editing) onNodePointerDown(node.id, e);
@@ -192,13 +200,25 @@ function TreeItem({
             {node.htabs.length}
           </span>
         )}
-        {activity && (
-          <span
-            className={`agent-dot ${activity.status}`}
-            title={agentActivityTitle(activity)}
-            aria-label={agentActivityTitle(activity)}
-          />
-        )}
+        {ACTIVITY_STATUSES.map((status: AgentActivityStatus) => {
+          const count = activity[status];
+          if (!count) return null;
+          const label = `${agentActivityTitle({
+            status,
+            updatedAt: 0,
+          })} (${count})`;
+          return (
+            <span
+              key={status}
+              className="tree-count activity-count"
+              title={label}
+              aria-label={label}
+            >
+              <span className={`agent-dot ${status}`} />
+              {count}
+            </span>
+          );
+        })}
       </div>
 
       {node.expanded &&

--- a/apps/web/src/i18n.ts
+++ b/apps/web/src/i18n.ts
@@ -118,6 +118,11 @@ const dictionaries: Record<Language, Record<string, string>> = {
     "agents.runtimeModelsTermany": "Use Termany models (coming soon)",
     "agents.openTerminal": "Open in terminal",
 
+    "activity.genericAgent": "AI assistant",
+    "activity.error": "{agent} needs attention",
+    "activity.done": "{agent} finished",
+    "activity.working": "{agent} is working",
+
     "agentChat.title": "What can I do for you?",
     "agentChat.placeholder": "Assign a task or ask anything",
     "agentChat.noModel": "Add a model in Settings to start a conversation",
@@ -597,6 +602,11 @@ const dictionaries: Record<Language, Record<string, string>> = {
     "agents.runtimeModelsAgent": "由 Agent 管理",
     "agents.runtimeModelsTermany": "使用 Termany 模型（即将支持）",
     "agents.openTerminal": "在终端中打开",
+
+    "activity.genericAgent": "AI 助手",
+    "activity.error": "{agent} 需要你处理",
+    "activity.done": "{agent} 已经完成",
+    "activity.working": "{agent} 正在处理",
 
     "agentChat.title": "有什么可以帮你的？",
     "agentChat.placeholder": "交给我一个任务，或问我任何问题",

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1149,6 +1149,20 @@ html.tauri #root {
   margin-left: 2px;
   flex-shrink: 0;
 }
+.activity-count {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-variant-numeric: tabular-nums;
+}
+.htab .activity-count {
+  padding-inline: 4px;
+}
+@media (prefers-reduced-motion: reduce) {
+  .agent-dot.working {
+    animation: none;
+  }
+}
 .tree-act {
   display: flex;
   align-items: center;

--- a/apps/web/src/terminal/agentActivityPrompt.ts
+++ b/apps/web/src/terminal/agentActivityPrompt.ts
@@ -1,0 +1,67 @@
+const AGENT_INPUT_PROMPT_RE = /^[›>](?:\s|$)/;
+const BOX_CHROME_RE = /^[\s│┃┆┊╎╏|]+|[\s│┃┆┊╎╏|]+$/g;
+const AGENT_PROMPT_SCAN_ROWS = 6;
+const CONFIRMATION_PROMPT_SCAN_ROWS = 14;
+const INLINE_CONFIRMATION_RE =
+  /(?:\[|\()\s*(?:y(?:es)?)\s*\/\s*(?:n(?:o)?)\s*(?:\]|\))|\byes\s*\/\s*no\b/i;
+const CONFIRMATION_QUESTION_RE =
+  /[?？]\s*$|\b(?:do you want|would you like|are you sure|allow|approve|permission|confirm|continue|proceed|choose|select|pick|which)\b|(?:是否|请选择|选择一个|需要你|允许|授权|批准|确认|同意|继续)/i;
+const POSITIVE_CHOICE_RE =
+  /^(?:[›❯>]\s*)?(?:\d+[.)]\s*)?(?:yes\b|allow\b|approve\b|continue\b|proceed\b|always allow\b|是(?:\s|$)|允许|授权|批准|同意|继续)/i;
+const NEGATIVE_CHOICE_RE =
+  /^(?:[›❯>]\s*)?(?:\d+[.)]\s*)?(?:no\b|deny\b|reject\b|cancel\b|否(?:\s|$)|不允许|拒绝|取消)/i;
+const SELECTED_CHOICE_RE = /^[›❯>]\s*(?:\d+[.)]\s*)?/;
+const NUMBERED_SELECTED_CHOICE_RE = /^[›❯>]\s*\d+[.)]\s*/;
+const CHOICE_INSTRUCTION_RE =
+  /\b(?:enter|return)\s+to\s+(?:select|confirm|continue)\b|\b(?:arrow keys?|up\s*\/\s*down|tab)\s+to\s+(?:navigate|select)\b|(?:按|使用).{0,12}(?:选择|确认|导航)/i;
+
+function cleanRow(line: string): string {
+  return line.replace(BOX_CHROME_RE, "").trim();
+}
+
+/** Find the live input row inside the bottom of a boxed agent TUI. */
+export function agentInputPromptVisible(visible: string): boolean {
+  const rows = visible.split("\n").map(cleanRow).filter(Boolean);
+  return rows
+    .slice(-AGENT_PROMPT_SCAN_ROWS)
+    .some((row) => AGENT_INPUT_PROMPT_RE.test(row));
+}
+
+/**
+ * Recognize a real interactive confirmation menu, not prose that happens to
+ * say "yes or no". Plain shell [y/N] prompts count only on the cursor row.
+ */
+export function agentConfirmationPromptVisible(
+  visible: string,
+  cursorLine = "",
+): boolean {
+  const liveRow = cleanRow(cursorLine);
+  if (liveRow && INLINE_CONFIRMATION_RE.test(liveRow)) return true;
+
+  const rows = visible
+    .split("\n")
+    .map(cleanRow)
+    .filter(Boolean)
+    .slice(-CONFIRMATION_PROMPT_SCAN_ROWS);
+  const hasQuestion = rows.some((row) => CONFIRMATION_QUESTION_RE.test(row));
+  const hasPositive = rows.some((row) => POSITIVE_CHOICE_RE.test(row));
+  const hasNegative = rows.some((row) => NEGATIVE_CHOICE_RE.test(row));
+  const hasSelectedChoice = rows.some((row) => SELECTED_CHOICE_RE.test(row));
+  const hasSelectedConfirmationChoice = rows.some(
+    (row) =>
+      SELECTED_CHOICE_RE.test(row) &&
+      (POSITIVE_CHOICE_RE.test(row) || NEGATIVE_CHOICE_RE.test(row)),
+  );
+  const hasSelectionInstructions = rows.some((row) =>
+    CHOICE_INSTRUCTION_RE.test(row),
+  );
+  const hasNumberedSelection = rows.some((row) =>
+    NUMBERED_SELECTED_CHOICE_RE.test(row),
+  );
+  return (
+    hasQuestion &&
+    ((hasPositive && hasNegative && hasSelectedConfirmationChoice) ||
+      (hasSelectedChoice &&
+        (hasSelectionInstructions || hasNumberedSelection)))
+  );
+}

--- a/apps/web/src/terminal/manager.ts
+++ b/apps/web/src/terminal/manager.ts
@@ -5,9 +5,14 @@ import { SearchAddon } from "@xterm/addon-search";
 import { WebglAddon } from "@xterm/addon-webgl";
 import { Terminal, type ITheme } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
+import { loadAgentConfigs } from "../agents";
 import { apiUrl } from "../api";
 import { DemoBackend, demoInteracted, isDemo } from "../demo";
 import { ACTIONS, loadKeybindings, matchChord } from "../keybindings";
+import {
+  agentConfirmationPromptVisible,
+  agentInputPromptVisible,
+} from "./agentActivityPrompt";
 import { registerLocalPathLinks } from "./localLinks";
 import { registerWebLinks } from "./webLinks";
 
@@ -46,6 +51,8 @@ export interface Session {
   /** Start a replacement backend after an ended remote session is selected. */
   restart?: () => void;
   connectionState?: "connecting" | "connected" | "disconnected";
+  /** Increments for every PTY output chunk, including in-place TUI redraws. */
+  contentVersion: number;
 }
 
 /**
@@ -210,19 +217,33 @@ export type AgentActivityStatus = "working" | "done" | "error";
 
 export type AgentActivity = {
   status: AgentActivityStatus;
-  agent?: "claude" | "codex" | "fastclaw";
+  agent?: string;
   updatedAt: number;
+  taskEpoch: number;
 };
 
 const agentActivities = new Map<string, AgentActivity>();
 const agentActivityListeners = new Set<() => void>();
 const agentSessionKinds = new Map<string, AgentActivity["agent"]>();
+let agentActivitySource: EventSource | null = null;
+let agentActivityInstance = "";
+let agentActivityRevision = -1;
+const retiredAgentActivityInstances = new Set<string>();
+const agentIdleTimers = new Map<string, number>();
+const agentIdleReports = new Map<string, number>();
+const agentSawAlternateScreen = new Set<string>();
+const agentReportedInactiveEpochs = new Map<string, number>();
+const agentTaskStartScreens = new Map<
+  string,
+  { taskEpoch: number; screen: string; contentVersion: number }
+>();
+const terminalInputSendChains = new Map<string, Promise<void>>();
+const commandSendChains = new Map<string, Promise<void>>();
 
 const AGENT_RE = /\b(OpenAI Codex|Codex CLI|Claude Code|FastClaw)\b|Use \/skills|\/model to change|bypass permissions/i;
 const CODEX_RE = /\b(OpenAI Codex|Codex CLI)\b/i;
 const CLAUDE_RE = /\bClaude Code\b/i;
 const FASTCLAW_RE = /\bFastClaw\b/i;
-const AGENT_COMMAND_RE = /^\s*(claude|codex|fastclaw)(?:\s|$)/i;
 const ERROR_RE =
   /\b(error|failed|failure|exception|fatal|panic|permission denied|timed out|rate limit|quota|authentication|unauthorized|forbidden|command not found)\b/i;
 const BENIGN_ERROR_RE = /\b(no errors?|0 errors?|without errors?)\b/i;
@@ -232,64 +253,163 @@ const WORKING_RE = /\b(working|thinking|running|executing|editing|applying|build
 const ALT_SCREEN_EXIT_RE = /\x1b\[\?1049l|\x1b\[\?47l|\x1b\[\?1047l/;
 const SHELL_PROMPT_RE = /(?:^|\n)[^\n]{0,96}(?:[$%#❯➜])\s*$/;
 const AGENT_IDLE_PROMPT_RE = /(?:^|\n)\s*[›>]\s*$/;
-// Matches ONE row that tuiInputPromptVisible() has already stripped of box
-// chrome. These markers are used by both known agents and otherwise unknown
-// chat-style TUIs, so image paste support does not depend on a vendor list.
-const TUI_INPUT_PROMPT_RE = /^[›>](?:\s|$)/;
-// Vertical box-drawing edges + padding around that row. Chat TUIs draw their
-// input inside a border, so the raw row reads "│ › fix a bug in @file      │".
-const BOX_CHROME_RE = /^[\s│┃┆┊╎╏|]+|[\s│┃┆┊╎╏|]+$/g;
-// How many non-empty rows up from the bottom to search for the input row. It is
-// rarely the last one — a bottom border and a hint line ("? for shortcuts")
-// usually sit below it.
-const TUI_PROMPT_SCAN_ROWS = 6;
-const DONE_ACTIVITY_TTL_MS = 30_000;
-const ERROR_ACTIVITY_TTL_MS = 5 * 60_000;
-const WORKING_ACTIVITY_STALE_MS = 2 * 60_000;
-let agentActivityPruneTimer: number | null = null;
+const AGENT_BUSY_SCREEN_RE =
+  /\b(?:esc|ctrl(?:\+|-)?c)\s+to\s+(?:interrupt|cancel|stop)\b|^[\s│┃┆┊╎╏|]*[•●◦✳✻⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]\s*(?:working|thinking|running|executing|editing|applying|building|testing|installing|searching|reading)\b/im;
+const AGENT_IDLE_CONFIRM_MS = 200;
+const AGENT_REGISTER_TIMEOUT_MS = 2_000;
 
 function notifyAgentActivity() {
   for (const listener of agentActivityListeners) listener();
 }
 
-function pruneExpiredAgentActivities() {
-  const now = Date.now();
-  let changed = false;
-  for (const [id, activity] of agentActivities) {
-    const ttl =
-      activity.status === "done"
-        ? DONE_ACTIVITY_TTL_MS
-        : activity.status === "error"
-          ? ERROR_ACTIVITY_TTL_MS
-          : WORKING_ACTIVITY_STALE_MS;
-    if (ttl && now - activity.updatedAt >= ttl) {
-      agentActivities.delete(id);
-      changed = true;
-    }
-  }
-  if (changed) notifyAgentActivity();
-  scheduleAgentActivityPrune();
+function clearAgentIdleTimer(id: string) {
+  const timer = agentIdleTimers.get(id);
+  if (timer !== undefined) window.clearTimeout(timer);
+  agentIdleTimers.delete(id);
 }
 
-function scheduleAgentActivityPrune() {
-  if (agentActivityPruneTimer !== null) {
-    window.clearTimeout(agentActivityPruneTimer);
-    agentActivityPruneTimer = null;
+function applyAgentActivityPayload(payload: any) {
+  if (!payload?.activities || typeof payload.activities !== "object") return;
+  if (
+    typeof payload.instance === "string" &&
+    Number.isFinite(Number(payload.revision))
+  ) {
+    const revision = Number(payload.revision);
+    if (
+      payload.instance === agentActivityInstance &&
+      revision < agentActivityRevision
+    ) {
+      return;
+    }
+    if (payload.instance !== agentActivityInstance) {
+      if (retiredAgentActivityInstances.has(payload.instance)) return;
+      if (agentActivityInstance) {
+        retiredAgentActivityInstances.add(agentActivityInstance);
+        if (retiredAgentActivityInstances.size > 8) {
+          retiredAgentActivityInstances.delete(
+            retiredAgentActivityInstances.values().next().value!,
+          );
+        }
+      }
+      agentActivityInstance = payload.instance;
+    }
+    agentActivityRevision = revision;
   }
-  let nextDelay = Infinity;
-  const now = Date.now();
-  for (const activity of agentActivities.values()) {
-    const ttl =
-      activity.status === "done"
-        ? DONE_ACTIVITY_TTL_MS
-        : activity.status === "error"
-          ? ERROR_ACTIVITY_TTL_MS
-          : WORKING_ACTIVITY_STALE_MS;
-    if (!ttl) continue;
-    nextDelay = Math.min(nextDelay, Math.max(0, ttl - (now - activity.updatedAt)));
+
+  const next = new Map<string, AgentActivity>();
+  for (const [id, value] of Object.entries(payload.activities)) {
+    if (!value || typeof value !== "object") continue;
+    const raw = value as Record<string, unknown>;
+    if (
+      raw.status !== "working" &&
+      raw.status !== "done" &&
+      raw.status !== "error"
+    ) {
+      continue;
+    }
+    const taskEpoch = Number(raw.taskEpoch);
+    if (!Number.isSafeInteger(taskEpoch) || taskEpoch <= 0) continue;
+    const agent =
+      typeof raw.agent === "string" && raw.agent.trim()
+        ? raw.agent.trim()
+        : undefined;
+    const updatedAt = Number(raw.updatedAt);
+    next.set(id, {
+      status: raw.status,
+      agent,
+      updatedAt: Number.isFinite(updatedAt) ? updatedAt : Date.now(),
+      taskEpoch,
+    });
+    if (agent) agentSessionKinds.set(id, agent);
   }
-  if (Number.isFinite(nextDelay)) {
-    agentActivityPruneTimer = window.setTimeout(pruneExpiredAgentActivities, nextDelay + 25);
+
+  const before = [...agentActivities.entries()]
+    .map(
+      ([id, activity]) =>
+        `${id}:${activity.status}:${activity.agent ?? ""}:${activity.updatedAt}:${activity.taskEpoch}`,
+    )
+    .join("|");
+  const after = [...next.entries()]
+    .map(
+      ([id, activity]) =>
+        `${id}:${activity.status}:${activity.agent ?? ""}:${activity.updatedAt}:${activity.taskEpoch}`,
+    )
+    .join("|");
+  if (before === after) {
+    for (const [id, activity] of next) {
+      if (activity.status === "working" || activity.status === "done") {
+        completeAgentActivityIfIdle(id);
+      }
+    }
+    return;
+  }
+
+  for (const [id, previous] of agentActivities) {
+    const current = next.get(id);
+    if (
+      !current ||
+      current.status !== "working" ||
+      current.taskEpoch !== previous.taskEpoch
+    ) {
+      clearAgentIdleTimer(id);
+    }
+  }
+  agentActivities.clear();
+  for (const [id, activity] of next) agentActivities.set(id, activity);
+  notifyAgentActivity();
+  for (const [id, activity] of next) {
+    if (activity.status === "working" || activity.status === "done") {
+      completeAgentActivityIfIdle(id);
+    }
+  }
+}
+
+function ensureAgentActivitySync() {
+  if (isDemo || agentActivitySource) return;
+  void fetch(`${apiUrl()}/api/activity`)
+    .then(async (response) => {
+      if (response.ok) applyAgentActivityPayload(await readJsonResponse(response));
+    })
+    .catch(() => {});
+  if (typeof EventSource === "undefined") return;
+  const source = new EventSource(`${apiUrl()}/api/activity/events`);
+  source.addEventListener("activity", (event) => {
+    try {
+      applyAgentActivityPayload(
+        JSON.parse((event as MessageEvent<string>).data),
+      );
+    } catch {
+      /* the next event is another complete snapshot */
+    }
+  });
+  source.onerror = () => {};
+  agentActivitySource = source;
+}
+
+async function registerRemoteAgentActivity(
+  id: string,
+  agent: string,
+): Promise<boolean> {
+  if (isDemo) return true;
+  const controller = new AbortController();
+  const timeout = window.setTimeout(
+    () => controller.abort(),
+    AGENT_REGISTER_TIMEOUT_MS,
+  );
+  try {
+    const response = await fetch(`${apiUrl()}/api/activity/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id, agent }),
+      signal: controller.signal,
+    });
+    if (!response.ok) return false;
+    applyAgentActivityPayload(await readJsonResponse(response));
+    return true;
+  } catch {
+    return false;
+  } finally {
+    window.clearTimeout(timeout);
   }
 }
 
@@ -308,42 +428,205 @@ function detectAgent(text: string): AgentActivity["agent"] | undefined {
   return undefined;
 }
 
-function setAgentActivity(id: string, status: AgentActivityStatus, agent?: AgentActivity["agent"]) {
+function setAgentActivity(
+  id: string,
+  status: AgentActivityStatus,
+  agent?: AgentActivity["agent"],
+  taskEpoch?: number,
+) {
   const prev = agentActivities.get(id);
   if (agent) agentSessionKinds.set(id, agent);
   const next = {
     status,
     agent: agent ?? prev?.agent,
     updatedAt: Date.now(),
+    taskEpoch:
+      taskEpoch ??
+      (status === "working" && prev?.status !== "working"
+        ? (prev?.taskEpoch ?? 0) + 1
+        : prev?.taskEpoch ?? 1),
   };
-  if (prev && prev.status === next.status && prev.agent === next.agent && Date.now() - prev.updatedAt < 1000) {
+  if (
+    prev &&
+    prev.status === next.status &&
+    prev.agent === next.agent &&
+    prev.taskEpoch === next.taskEpoch &&
+    Date.now() - prev.updatedAt < 1000
+  ) {
     return;
   }
   agentActivities.set(id, next);
   notifyAgentActivity();
-  scheduleAgentActivityPrune();
 }
 
-function visibleScreenLooksIdle(id: string): boolean {
+function startLocalAgentActivity(
+  id: string,
+  agent?: AgentActivity["agent"],
+) {
+  const nextEpoch = (agentActivities.get(id)?.taskEpoch ?? 0) + 1;
+  const session = sessions.get(id);
+  clearAgentIdleTimer(id);
+  agentIdleReports.delete(id);
+  agentSawAlternateScreen.delete(id);
+  if (session?.term.buffer.active.type === "alternate") {
+    agentSawAlternateScreen.add(id);
+  }
+  agentReportedInactiveEpochs.delete(id);
+  agentTaskStartScreens.set(id, {
+    taskEpoch: nextEpoch,
+    screen: sessionVisibleText(id),
+    contentVersion: session?.contentVersion ?? 0,
+  });
+  setAgentActivity(id, "working", agent, nextEpoch);
+}
+
+type RenderedAgentTransition = {
+  status: Extract<AgentActivityStatus, "done" | "error">;
+  agentActive: boolean;
+};
+
+function visibleScreenActivityTransition(
+  id: string,
+): RenderedAgentTransition | null {
+  const session = sessions.get(id);
+  if (!session) return null;
   const text = sessionVisibleText(id);
-  if (!text.trim()) return false;
+  if (!text.trim()) return null;
+  if (session.term.buffer.active.type === "alternate") {
+    agentSawAlternateScreen.add(id);
+  }
+  if (agentConfirmationPromptVisible(text, sessionCursorLine(id))) {
+    return { status: "error", agentActive: true };
+  }
+  const busyTail = text
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .filter((line) => line.trim())
+    .slice(-12)
+    .join("\n");
+  if (AGENT_BUSY_SCREEN_RE.test(busyTail)) return null;
+  if (agentInputPromptVisible(text)) {
+    return { status: "done", agentActive: true };
+  }
   const tail = text
     .split("\n")
     .map((line) => line.trimEnd())
     .filter((line) => line.trim())
     .slice(-4)
     .join("\n");
-  return AGENT_IDLE_PROMPT_RE.test(tail) || SHELL_PROMPT_RE.test(tail);
+  if (
+    session.term.buffer.active.type === "normal" &&
+    agentSawAlternateScreen.has(id) &&
+    SHELL_PROMPT_RE.test(tail)
+  ) {
+    return { status: "done", agentActive: false };
+  }
+  return null;
 }
 
 function completeAgentActivityIfIdle(id: string) {
   const activity = agentActivities.get(id);
-  if (activity?.status === "working" && visibleScreenLooksIdle(id)) {
-    setAgentActivity(id, "done", activity.agent);
+  const session = sessions.get(id);
+  if (
+    !activity ||
+    !session ||
+    (activity.status !== "working" && activity.status !== "done")
+  ) {
+    clearAgentIdleTimer(id);
+    return;
   }
+  const transition = visibleScreenActivityTransition(id);
+  const start = agentTaskStartScreens.get(id);
+  if (
+    activity.status === "working" &&
+    start?.taskEpoch === activity.taskEpoch &&
+    start.screen === sessionVisibleText(id) &&
+    start.contentVersion === session.contentVersion
+  ) {
+    clearAgentIdleTimer(id);
+    return;
+  }
+  if (
+    activity.status === "done" &&
+    (transition?.status !== "done" ||
+      transition.agentActive ||
+      agentReportedInactiveEpochs.get(id) === activity.taskEpoch)
+  ) {
+    clearAgentIdleTimer(id);
+    return;
+  }
+  if (!transition) {
+    clearAgentIdleTimer(id);
+    return;
+  }
+  if (
+    agentIdleTimers.has(id) ||
+    agentIdleReports.get(id) === activity.taskEpoch
+  ) {
+    return;
+  }
+
+  const observedEpoch = activity.taskEpoch;
+  const observedStatus = transition.status;
+  agentIdleTimers.set(
+    id,
+    window.setTimeout(async () => {
+      agentIdleTimers.delete(id);
+      const latest = agentActivities.get(id);
+      const confirmed = visibleScreenActivityTransition(id);
+      if (
+        !latest ||
+        (latest.status !== "working" && latest.status !== "done") ||
+        latest.taskEpoch !== observedEpoch ||
+        !confirmed ||
+        confirmed.status !== observedStatus ||
+        (latest.status === "done" &&
+          (confirmed.status !== "done" || confirmed.agentActive))
+      ) {
+        return;
+      }
+      if (isDemo) {
+        if (latest.status === "working") {
+          setAgentActivity(
+            id,
+            confirmed.status,
+            latest.agent,
+            observedEpoch,
+          );
+        }
+        return;
+      }
+      agentIdleReports.set(id, observedEpoch);
+      try {
+        const response = await fetch(`${apiUrl()}/api/activity/report`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            id,
+            taskEpoch: observedEpoch,
+            status: confirmed.status,
+            agentActive: confirmed.agentActive,
+          }),
+        });
+        if (response.ok) {
+          if (confirmed.status === "done" && !confirmed.agentActive) {
+            agentReportedInactiveEpochs.set(id, observedEpoch);
+          }
+          applyAgentActivityPayload(await readJsonResponse(response));
+        }
+      } catch {
+        // A later terminal write or SSE event will try the observation again.
+      } finally {
+        if (agentIdleReports.get(id) === observedEpoch) {
+          agentIdleReports.delete(id);
+        }
+      }
+    }, AGENT_IDLE_CONFIRM_MS),
+  );
 }
 
 function updateAgentActivityFromOutput(id: string, data: string) {
+  if (!isDemo) return;
   const text = stripTerminalControls(data);
   if (!text.trim()) return;
   const prev = agentActivities.get(id);
@@ -369,16 +652,76 @@ function updateAgentActivityFromOutput(id: string, data: string) {
 }
 
 function noteAgentInput(id: string, data: string) {
+  clearAgentIdleTimer(id);
+  agentIdleReports.delete(id);
+  if (!isDemo) return;
   if (!data.includes("\r")) return;
   const session = sessions.get(id);
   if (!session) return;
   if (agentActivities.has(id) || AGENT_RE.test(sessionVisibleText(id))) {
-    setAgentActivity(id, "working");
+    startLocalAgentActivity(id);
   }
+}
+
+function submittedAgentForTerminalInput(
+  id: string,
+  data: string,
+): string | undefined {
+  if (isDemo || !data.includes("\r")) return undefined;
+  const visible = sessionVisibleText(id);
+  if (
+    !agentInputPromptVisible(visible) &&
+    !agentConfirmationPromptVisible(visible, sessionCursorLine(id))
+  ) {
+    return undefined;
+  }
+  return (
+    agentActivities.get(id)?.agent ??
+    agentSessionKinds.get(id) ??
+    detectAgent(visible)
+  );
+}
+
+function writeTerminalInput(id: string, session: Session, data: string) {
+  const agent = submittedAgentForTerminalInput(id, data);
+  const previous = terminalInputSendChains.get(id);
+  if (!agent && !previous) {
+    session.backend.write(data);
+    return;
+  }
+
+  // Yellow appears immediately, while the server registration remains ordered
+  // before Enter so a fast completion cannot be overwritten by a late start.
+  if (agent) startLocalAgentActivity(id, agent);
+  const run = (previous ?? Promise.resolve())
+    .catch(() => {})
+    .then(async () => {
+      if (agent) {
+        await registerRemoteAgentActivity(id, agent);
+        const registered = agentActivities.get(id);
+        if (registered?.status === "working") {
+          clearAgentIdleTimer(id);
+          agentTaskStartScreens.set(id, {
+            taskEpoch: registered.taskEpoch,
+            screen: sessionVisibleText(id),
+            contentVersion: session.contentVersion,
+          });
+        }
+      }
+      if (sessions.get(id) === session) session.backend.write(data);
+    });
+  terminalInputSendChains.set(id, run);
+  const cleanup = () => {
+    if (terminalInputSendChains.get(id) === run) {
+      terminalInputSendChains.delete(id);
+    }
+  };
+  void run.then(cleanup, cleanup);
 }
 
 export function subscribeAgentActivity(listener: () => void): () => void {
   agentActivityListeners.add(listener);
+  ensureAgentActivitySync();
   return () => agentActivityListeners.delete(listener);
 }
 
@@ -386,7 +729,9 @@ export function agentActivitySnapshot(ids: string[]): string {
   return ids.map((id) => {
     id = activeSessionId(id);
     const activity = agentActivities.get(id);
-    return activity ? `${id}:${activity.status}:${activity.agent ?? ""}:${activity.updatedAt}` : `${id}:`;
+    return activity
+      ? `${id}:${activity.status}:${activity.agent ?? ""}:${activity.updatedAt}:${activity.taskEpoch}`
+      : `${id}:`;
   }).join("|");
 }
 
@@ -407,18 +752,56 @@ export function aggregateAgentActivity(ids: string[]): AgentActivity | null {
   return best;
 }
 
-export function agentActivityTitle(activity: AgentActivity): string {
-  const who =
-    activity.agent === "claude"
-      ? "Claude"
-      : activity.agent === "codex"
-        ? "Codex"
-        : activity.agent === "fastclaw"
-          ? "FastClaw"
-          : "Agent";
-  if (activity.status === "error") return `${who} reported an error`;
-  if (activity.status === "done") return `${who} completed`;
-  return `${who} is working`;
+export type AgentActivitySummary = Record<AgentActivityStatus, number>;
+
+export function agentActivitySummary(ids: string[]): AgentActivitySummary {
+  const summary: AgentActivitySummary = { working: 0, done: 0, error: 0 };
+  for (const id of new Set(ids)) {
+    const activity = agentActivities.get(activeSessionId(id));
+    if (activity) summary[activity.status]++;
+  }
+  return summary;
+}
+
+export function acknowledgeAgentActivities(ids: string[]) {
+  const items = [...new Set(ids.map(activeSessionId))].flatMap((id) => {
+    const activity = agentActivities.get(id);
+    return activity?.status === "done"
+      ? [{ id, taskEpoch: activity.taskEpoch }]
+      : [];
+  });
+  if (!items.length) return;
+  if (isDemo) {
+    for (const { id, taskEpoch } of items) {
+      if (agentActivities.get(id)?.taskEpoch === taskEpoch) {
+        agentActivities.delete(id);
+      }
+    }
+    notifyAgentActivity();
+    return;
+  }
+  fetch(`${apiUrl()}/api/activity/ack`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ items }),
+  })
+    .then(async (response) => {
+      if (response.ok) {
+        applyAgentActivityPayload(await readJsonResponse(response));
+      }
+    })
+    .catch(() => {});
+}
+
+export function agentActivityTitle(
+  activity: Pick<AgentActivity, "status" | "agent" | "updatedAt">,
+): string {
+  const language = getLanguage();
+  const agent = activity.agent
+    ? loadAgentConfigs().find((config) => config.id === activity.agent)?.name ??
+      activity.agent
+    : translate(language, "activity.genericAgent");
+  return translate(language, `activity.${activity.status}`, { agent });
 }
 
 /**
@@ -825,6 +1208,7 @@ function getSession(id: string, cwdFrom?: string[], sshTarget?: string, paneId =
     restartAttempts: 0,
     ended: false,
     connectionState: sshTarget ? "connecting" : undefined,
+    contentVersion: 0,
   };
   sessions.set(id, session);
   if (sshTarget) notifyConnectionStatus();
@@ -835,6 +1219,7 @@ function getSession(id: string, cwdFrom?: string[], sshTarget?: string, paneId =
         session.connectionState = "connected";
         notifyConnectionStatus();
       }
+      session.contentVersion++;
       updateAgentActivityFromOutput(id, data);
       if (replaying) {
         pendingOutput.push(data);
@@ -900,7 +1285,7 @@ function getSession(id: string, cwdFrom?: string[], sshTarget?: string, paneId =
       return;
     }
     noteAgentInput(id, data);
-    session.backend.write(data);
+    writeTerminalInput(id, session, data);
   });
 
   // Select-to-copy only after an actual selection gesture. The old listener
@@ -1294,22 +1679,61 @@ export function onSearchResults(
   return () => sub.dispose();
 }
 
+function configuredAgentForCommand(command: string) {
+  const inputs = command
+    .split(/\s*(?:&&|;)\s*/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+  return loadAgentConfigs()
+    .filter((agent) => agent.command.trim())
+    .sort((a, b) => b.command.trim().length - a.command.trim().length)
+    .find((agent) => {
+      const configured = agent.command.trim();
+      return inputs.some(
+        (input) =>
+          input === configured ||
+          (input.startsWith(configured) &&
+            /^\s/.test(input.slice(configured.length))),
+      );
+    });
+}
+
+async function performSendCommand(id: string, command: string): Promise<void> {
+  const session = sessions.get(id);
+  if (!session) return;
+  const agent = configuredAgentForCommand(command);
+  if (agent) {
+    agentSessionKinds.set(id, agent.id);
+    startLocalAgentActivity(id, agent.id);
+    // Register before the command can emit a completion transition.
+    await registerRemoteAgentActivity(id, agent.id);
+    if (sessions.get(id) !== session) return;
+  }
+  clearAgentIdleTimer(id);
+  session.backend.write(`${command}\r`);
+}
+
 /**
  * Type a command into the session's shell and press Enter, as if the user
- * had. Used to `cd` an existing terminal to wherever the file tree navigated
- * to when switching back from it — a no-op (and safe) if `id` has no live
- * session yet, same as clearSession above.
+ * had. Agent launch commands register yellow before they can produce output.
  */
-export function sendCommand(id: string, command: string) {
+export function sendCommand(id: string, command: string): Promise<void> {
   id = activeSessionId(id);
-  const agent = AGENT_COMMAND_RE.exec(command)?.[1]?.toLowerCase() as AgentActivity["agent"] | undefined;
-  if (agent) setAgentActivity(id, "working", agent);
-  sessions.get(id)?.backend.write(`${command}\r`);
+  const previous = commandSendChains.get(id) ?? Promise.resolve();
+  const run = previous
+    .catch(() => {})
+    .then(() => performSendCommand(id, command));
+  commandSendChains.set(id, run);
+  const cleanup = () => {
+    if (commandSendChains.get(id) === run) commandSendChains.delete(id);
+  };
+  void run.then(cleanup, cleanup);
+  return run;
 }
 
 export function queueCommand(id: string, command: string) {
   if (sessions.has(activeSessionId(id))) {
-    sendCommand(id, command);
+    void sendCommand(id, command);
     return;
   }
   pendingCommands.set(id, [...(pendingCommands.get(id) ?? []), command]);
@@ -1341,25 +1765,7 @@ export function sessionLooksLikeAgentInput(id: string): boolean {
   // Some chat TUIs (FastClaw included) deliberately stay in the normal
   // buffer. Recognize their visible input row directly instead of requiring
   // the command or product name to be registered with Termany.
-  return tuiInputPromptVisible(visible);
-}
-
-/**
- * Does the visible screen show a chat-style TUI input line?
- *
- * Scans the last few NON-EMPTY rows (the same shape as visibleScreenLooksIdle)
- * instead of anchoring to the end of the text. An agent CLI wraps its input in
- * a box and parks a bottom border plus a hint line under it, so the prompt is
- * almost never the final character of the screen — an end-anchored match found
- * it only in the degenerate case, which is why pasting an image at a Codex
- * prompt fell through to the "no TUI input prompt" branch.
- */
-function tuiInputPromptVisible(visible: string): boolean {
-  const rows = visible
-    .split("\n")
-    .map((line) => line.replace(BOX_CHROME_RE, ""))
-    .filter(Boolean);
-  return rows.slice(-TUI_PROMPT_SCAN_ROWS).some((row) => TUI_INPUT_PROMPT_RE.test(row));
+  return agentInputPromptVisible(visible);
 }
 
 function sessionVisibleText(id: string): string {
@@ -1375,15 +1781,35 @@ function sessionVisibleText(id: string): string {
   return lines.join("\n");
 }
 
+function sessionCursorLine(id: string): string {
+  const session = sessions.get(id);
+  if (!session) return "";
+  const buf = session.term.buffer.active;
+  return (
+    buf
+      .getLine(buf.baseY + buf.cursorY)
+      ?.translateToString(true)
+      .trimEnd() ?? ""
+  );
+}
+
 /** Permanently destroy a session — only when the user closes the pane/tab. */
 export function disposeSession(id: string) {
   const s = sessions.get(id);
-  if (!s) return;
-  s.backend.dispose();
-  s.term.dispose();
-  s.el.remove();
-  sessions.delete(id);
+  if (s) {
+    s.backend.dispose();
+    s.term.dispose();
+    s.el.remove();
+    sessions.delete(id);
+  }
   notifyConnectionStatus();
+  clearAgentIdleTimer(id);
+  agentIdleReports.delete(id);
+  agentSawAlternateScreen.delete(id);
+  agentReportedInactiveEpochs.delete(id);
+  agentTaskStartScreens.delete(id);
+  terminalInputSendChains.delete(id);
+  commandSendChains.delete(id);
   if (agentActivities.delete(id)) notifyAgentActivity();
   agentSessionKinds.delete(id);
   restoreSnapshots.delete(id);
@@ -1411,6 +1837,13 @@ export function disposePaneSessions(paneId: string) {
       sessions.delete(id);
     }
     restoreSnapshots.delete(id);
+    clearAgentIdleTimer(id);
+    agentIdleReports.delete(id);
+    agentSawAlternateScreen.delete(id);
+    agentReportedInactiveEpochs.delete(id);
+    agentTaskStartScreens.delete(id);
+    terminalInputSendChains.delete(id);
+    commandSendChains.delete(id);
     if (agentActivities.delete(id)) notifyAgentActivity();
     agentSessionKinds.delete(id);
   }

--- a/apps/web/tests/agentActivity.test.ts
+++ b/apps/web/tests/agentActivity.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import {
+  agentConfirmationPromptVisible,
+  agentInputPromptVisible,
+} from "../src/terminal/agentActivityPrompt.ts";
+
+function source(path: string): string {
+  return readFileSync(new URL(path, import.meta.url), "utf8");
+}
+
+test("activity state is generation-safe and synchronized from the server", () => {
+  const manager = source("../src/terminal/manager.ts");
+
+  assert.match(manager, /taskEpoch: number/);
+  assert.match(manager, /\/api\/activity\/events/);
+  assert.match(manager, /\/api\/activity\/register/);
+  assert.match(manager, /\/api\/activity\/report/);
+  assert.match(manager, /taskEpoch: observedEpoch/);
+  assert.doesNotMatch(manager, /WORKING_ACTIVITY_STALE_MS/);
+});
+
+test("page and tab indicators expose separate counts for all three states", () => {
+  const manager = source("../src/terminal/manager.ts");
+  const sidebar = source("../src/components/TreeSidebar.tsx");
+  const tabs = source("../src/components/HTabBar.tsx");
+
+  assert.match(manager, /export function agentActivitySummary/);
+  assert.match(manager, /export function acknowledgeAgentActivities/);
+  assert.match(sidebar, /\["working", "done", "error"\]/);
+  assert.match(sidebar, /agentActivitySummary\(allLeafIds\)/);
+  assert.match(sidebar, /acknowledgeAgentActivities\(viewedLeafIds\)/);
+  assert.match(tabs, /\["working", "done", "error"\]/);
+  assert.match(tabs, /agentActivitySummary\(ids\)/);
+  assert.match(tabs, /acknowledgeAgentActivities\(ids\)/);
+});
+
+test("individual pane headers retain their own traffic light", () => {
+  const panes = source("../src/components/SplitView.tsx");
+
+  assert.match(panes, /aggregateAgentActivity\(\[leaf\.id\]\)/);
+  assert.match(panes, /className=\{`agent-dot \$\{activity\.status\}`\}/);
+  assert.match(panes, /acknowledgeAgentActivities\(\[leaf\.id\]\)/);
+});
+
+test("recognizes idle input and interactive confirmation screens", () => {
+  const idle = [
+    "╭──────────────────────────╮",
+    "│ ›                        │",
+    "╰──────────────────────────╯",
+    "? for shortcuts",
+  ].join("\n");
+  const confirmation = [
+    "Do you want to allow this command?",
+    "› 1. Yes, allow",
+    "  2. No, cancel",
+    "Enter to confirm",
+  ].join("\n");
+
+  assert.equal(agentInputPromptVisible(idle), true);
+  assert.equal(agentConfirmationPromptVisible(confirmation), true);
+  assert.equal(
+    agentConfirmationPromptVisible("The documentation says yes or no."),
+    false,
+  );
+  assert.equal(
+    agentConfirmationPromptVisible("", "Continue deployment? [y/n]"),
+    true,
+  );
+});


### PR DESCRIPTION
## What changed

- replace the single highest-priority agent dot on sidebar pages and terminal tabs with separate working, finished, and needs-attention counts
- keep the current status dot on each individual terminal pane
- move the activity ledger to the PTY server and broadcast complete snapshots to every app window
- rotate each task through yellow (working), green (finished), or red (needs attention), using task epochs so stale completion and acknowledgement events cannot overwrite newer work
- clear only finished tasks when their page, tab, or pane is viewed; red and yellow states remain visible
- recognize configured agents, common CLI launchers and aliases, rendered idle/confirmation prompts, and explicit OSC 778 activity signals
- add English and Chinese status labels plus focused server and web tests

## Why

The existing client-only indicator collapses every terminal under a page or tab into one priority dot. That hides how many agents are working, finished, or waiting for input, and timer-based state can disappear or diverge between windows.

## User impact

Users can read the state of several agent terminals at a glance: yellow shows active work, green shows completed tasks, and red calls out tasks that need a decision or input. The adjacent number shows how many terminals are in each state.

## Validation

- `fnm exec --using=22 npm -w @termany/server test` — 23 tests passed
- `fnm exec --using=22 npm -w @termany/web test` — 11 tests passed
- `fnm exec --using=22 npm run build:web`
- `git diff --cached --check`
