### PR TITLE
fix: Ctrl+D 关闭 pane，而不是原地复活一个新 shell

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -243,6 +243,18 @@ type ClientMessage =
   | { type: "input"; data: string }
   | { type: "resize"; cols: number; rows: number };
 
+// Mirrors packages/core's ShellExit wire format — kept in sync by hand because
+// this server bundles standalone (see scripts/bundle-server.mjs) and does not
+// depend on the workspace package. The frontend needs to tell "the user typed
+// `exit`" apart from "the shell crashed" to decide whether to close the pane,
+// and the CLOSE frame is the only channel that can't be confused with terminal
+// output. 4000-4999 is WebSocket's private-use close-code range.
+const SHELL_EXIT_CLOSE_CODE = 4000;
+
+function encodeShellExit(exitCode: number, signal: number | undefined): string {
+  return JSON.stringify({ exitCode, signal: signal ?? 0 });
+}
+
 // --- scroll history ---------------------------------------------------------
 // Every live session tails its raw PTY output into a per-session ring
 // (Wave-style: history survives restarts without the frontend serializing
@@ -450,7 +462,7 @@ function wireSession(id: string | undefined, session: PtySession): void {
           `\r\n\x1b[2m[termany] shell exited (code: ${exitCode}, signal: ${signal ?? "none"})\x1b[0m\r\n`
         );
       }
-      session.ws.close();
+      session.ws.close(SHELL_EXIT_CLOSE_CODE, encodeShellExit(exitCode, signal));
     }
     if (id) {
       activityTracker.noteExit(id, exitCode, signal);

--- a/apps/server/tests/shellExit.test.ts
+++ b/apps/server/tests/shellExit.test.ts
@@ -1,0 +1,113 @@
+/**
+ * The shell-exit wire protocol, end to end against a real server and a real PTY.
+ *
+ * The frontend decides whether a dead shell should take its pane with it (see
+ * apps/web/src/terminal/shellExit.ts). That decision is only as good as the exit
+ * status reaching it, and the status travels on the WebSocket CLOSE frame — a
+ * path no unit test covers, since it involves node-pty, the ws server, and the
+ * browser's CloseEvent semantics all agreeing.
+ *
+ * Runs the server under a throwaway HOME so it never touches ~/.termany.
+ */
+import assert from "node:assert/strict";
+import { spawn, type ChildProcess } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { after, before, test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const SHELL_EXIT_CLOSE_CODE = 4000;
+// Offset by pid so concurrent runs (or a leftover server from a killed run)
+// can't collide on the port.
+const PORT = 51000 + (process.pid % 4000);
+const SERVER_ENTRY = fileURLToPath(new URL("../src/index.ts", import.meta.url));
+
+let server: ChildProcess;
+let home: string;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+before(async () => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), "termany-shell-exit-"));
+  server = spawn(process.execPath, ["--import", "tsx", SERVER_ENTRY], {
+    env: {
+      ...process.env,
+      HOME: home,
+      TERMANY_PORT: String(PORT),
+      // bash rather than the developer's own shell: the assertions below depend
+      // on POSIX `exit`/EOF status semantics, not on someone's zsh config.
+      TERMANY_SHELL: "/bin/bash",
+    },
+    stdio: "ignore",
+  });
+  for (let i = 0; i < 100; i++) {
+    try {
+      await fetch(`http://localhost:${PORT}/api/health`);
+      return;
+    } catch {
+      await sleep(200);
+    }
+  }
+  throw new Error(`server did not start on port ${PORT}`);
+});
+
+after(() => {
+  server?.kill("SIGKILL");
+  if (home) fs.rmSync(home, { recursive: true, force: true });
+});
+
+/**
+ * Type `command` into a fresh session and report how the CLOSE frame described
+ * the shell's death. Uses Node's built-in WHATWG WebSocket, so the CloseEvent
+ * observed here is the one WebSocketBackend sees in the browser.
+ */
+async function exitStatusOf(session: string, command: string): Promise<unknown> {
+  const closed = new Promise<{ code: number; reason: string }>((resolve, reject) => {
+    const ws = new WebSocket(`ws://localhost:${PORT}/?session=${session}`);
+    const timer = setTimeout(() => reject(new Error(`${session} never closed`)), 20_000);
+    ws.addEventListener("open", () => {
+      // Let bash finish its startup and print a prompt before typing at it.
+      setTimeout(() => ws.send(JSON.stringify({ type: "input", data: command })), 1200);
+    });
+    ws.addEventListener("close", (event) => {
+      clearTimeout(timer);
+      resolve({ code: event.code, reason: event.reason });
+    });
+    ws.addEventListener("error", () => {
+      clearTimeout(timer);
+      reject(new Error(`${session} socket error`));
+    });
+  });
+  const { code, reason } = await closed;
+  assert.equal(code, SHELL_EXIT_CLOSE_CODE, `expected a shell-exit close frame, got ${code}`);
+  return JSON.parse(reason);
+}
+
+test("a deliberate exit reports a clean status", async () => {
+  assert.deepEqual(await exitStatusOf("test-clean-exit", "true\nexit\n"), {
+    exitCode: 0,
+    signal: 0,
+  });
+});
+
+test("EOF after a failed command reports that command's status", async () => {
+  // Ctrl+D is still the user asking to close the pane, but bash hands back the
+  // last command's status — so the frontend must NOT read a non-zero code here
+  // as "crashed". Locking the behaviour in: this is the case that makes an
+  // exit-code-only rule wrong.
+  assert.deepEqual(await exitStatusOf("test-eof-after-failure", "false\n\x04"), {
+    exitCode: 1,
+    signal: 0,
+  });
+});
+
+test("a signalled kill is distinguishable from a clean exit", async () => {
+  // The exit code alone is 0 here — identical to a graceful `exit`. Only the
+  // signal separates "the OS killed my shell" from "the user closed the pane",
+  // which is why it has to survive the trip to the frontend.
+  assert.deepEqual(await exitStatusOf("test-signalled", "kill -9 $$\n"), {
+    exitCode: 0,
+    signal: 9,
+  });
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -22,6 +22,7 @@ import {
   resetTerminalFontSize,
   scrollSessionToBottom,
   scrollSessionToTop,
+  subscribeShellNaturalExit,
 } from "./terminal/manager";
 import { openLocalPathsInFocusedSession } from "./terminal/openLocalPath";
 import { checkForUpdate } from "./updater";
@@ -301,6 +302,15 @@ export function App() {
     document.addEventListener("keydown", onKey, true);
     return () => document.removeEventListener("keydown", onKey, true);
   }, []);
+
+  // A shell the user ended on purpose takes its pane with it, exactly as if
+  // they had pressed the close-pane shortcut. Listening here rather than in
+  // TerminalPane so a pane sitting in a backgrounded tab — which has no mounted
+  // component — still closes.
+  useEffect(
+    () => subscribeShellNaturalExit((paneId) => useStore.getState().closePane(paneId)),
+    []
+  );
 
   // Desktop: check for a new release once, shortly after startup (stays quiet —
   // just lights up the update badges; the install lives in Settings → About).

--- a/apps/web/src/state/store.ts
+++ b/apps/web/src/state/store.ts
@@ -694,9 +694,18 @@ function subtreeLeafIds(node: TreeNode): string[] {
 
 const first = initialWorkspace("ws 1");
 
+/** Map one workspace by id; pass others through untouched. */
+function inWs(
+  workspaces: Workspace[],
+  workspaceId: string,
+  fn: (ws: Workspace) => Workspace
+): Workspace[] {
+  return workspaces.map((ws) => (ws.id === workspaceId ? fn(ws) : ws));
+}
+
 /** Map only the active workspace; pass others through untouched. */
 function inActiveWs(s: State, fn: (ws: Workspace) => Workspace): Workspace[] {
-  return s.workspaces.map((ws) => (ws.id === s.activeWorkspace ? fn(ws) : ws));
+  return inWs(s.workspaces, s.activeWorkspace, fn);
 }
 
 /** Update a leaf by globally unique id even if its tab was backgrounded while
@@ -721,17 +730,53 @@ function updateLeafEverywhere(
   return workspaces.map((workspace) => ({ ...workspace, roots: updateNodes(workspace.roots) }));
 }
 
-/** Close one leaf in the active tab; drops the whole tab if it was the last pane. */
+/**
+ * Locate the workspace / page / tab a leaf lives in. Leaf ids are globally
+ * unique (same assumption updateLeafEverywhere leans on), so the first hit is
+ * the only hit.
+ */
+function findLeafHome(
+  workspaces: Workspace[],
+  leafId: string
+): { workspaceId: string; nodeId: string; htab: HTab } | undefined {
+  const search = (
+    nodes: TreeNode[],
+    workspaceId: string
+  ): { workspaceId: string; nodeId: string; htab: HTab } | undefined => {
+    for (const node of nodes) {
+      const htab = node.htabs.find((h) => leafIds(h.layout).includes(leafId));
+      if (htab) return { workspaceId, nodeId: node.id, htab };
+      const hit = search(node.children, workspaceId);
+      if (hit) return hit;
+    }
+    return undefined;
+  };
+  for (const ws of workspaces) {
+    const hit = search(ws.roots, ws.id);
+    if (hit) return hit;
+  }
+  return undefined;
+}
+
+/**
+ * Close one leaf; drops the whole tab if it was the last pane.
+ *
+ * Resolves the leaf's own tab rather than assuming the active one — a pane can
+ * now close itself when its shell exits (see terminal/shellExit.ts), and that
+ * can land on a backgrounded tab or a workspace the user has since switched
+ * away from. Passing a leaf from the active tab, as every UI path does, behaves
+ * exactly as before.
+ */
 function closeLeaf(s: State, leafId: string): Partial<State> {
-  const node = activeNode(s);
-  const htab = node?.htabs.find((h) => h.id === node.activeHTab);
-  if (!node || !htab) return {};
+  const home = findLeafHome(s.workspaces, leafId);
+  if (!home) return {};
+  const { workspaceId, nodeId, htab } = home;
   disposePaneSessions(leafId);
   const layout = removeLeaf(htab.layout, leafId);
   return {
-    workspaces: inActiveWs(s, (ws) => ({
+    workspaces: inWs(s.workspaces, workspaceId, (ws) => ({
       ...ws,
-      roots: updateNode(ws.roots, ws.activeNode, (n) => {
+      roots: updateNode(ws.roots, nodeId, (n) => {
         if (layout === null) {
           const htabs = n.htabs.filter((h) => h.id !== htab.id);
           if (htabs.length === 0) {

--- a/apps/web/src/terminal/manager.ts
+++ b/apps/web/src/terminal/manager.ts
@@ -15,6 +15,11 @@ import {
   agentInputPromptVisible,
 } from "./agentActivityPrompt";
 import { registerLocalPathLinks } from "./localLinks";
+import {
+  MAX_AUTO_RESTARTS,
+  RESTART_HEALTHY_MS,
+  shellExitDisposition,
+} from "./shellExit";
 import { registerWebLinks } from "./webLinks";
 
 /**
@@ -55,19 +60,6 @@ export interface Session {
   /** Increments for every PTY output chunk, including in-place TUI redraws. */
   contentVersion: number;
 }
-
-/**
- * The shell exiting on its own (typed `exit`, crashed) used to just leave the
- * pane dead with a "[session ended]" message — the user had to close the tab
- * and reopen a new one to keep working. Auto-respawning a fresh shell in the
- * same pane instead makes that recoverable by default. Capped so a shell
- * that dies instantly on every launch (bad rc file, missing binary) doesn't
- * spin forever — the counter resets once a shell survives a little while, so
- * this only kicks in for a tight crash loop, not e.g. someone repeatedly
- * typing `exit`.
- */
-const MAX_AUTO_RESTARTS = 5;
-const RESTART_HEALTHY_MS = 3000;
 
 /**
  * A mouse-wheel scroll only moves xterm's DOM scroll container immediately;
@@ -180,6 +172,7 @@ const pendingCommands = new Map<string, string[]>();
 const scrollListeners = new Map<string, Set<(state: TerminalScrollState) => void>>();
 const connectionStatusListeners = new Set<() => void>();
 const SSH_EXIT_EVENT = "termany:ssh-session-exited";
+const SHELL_EXIT_EVENT = "termany:shell-session-exited";
 
 function notifyConnectionStatus() {
   for (const listener of connectionStatusListeners) listener();
@@ -203,6 +196,23 @@ export function subscribeSshNaturalExit(paneId: string, listener: () => void): (
   };
   window.addEventListener(SSH_EXIT_EVENT, onExit);
   return () => window.removeEventListener(SSH_EXIT_EVENT, onExit);
+}
+
+/**
+ * A local shell ended deliberately and its pane should go away with it.
+ *
+ * Global rather than per-pane (unlike the SSH hook above): the pane whose shell
+ * exited may be sitting in a backgrounded tab with no mounted component to hear
+ * about it, and it still needs to close. The store can't be imported here — it
+ * already imports this module — so App owns the listener.
+ */
+export function subscribeShellNaturalExit(listener: (paneId: string) => void): () => void {
+  const onExit = (event: Event) => {
+    const paneId = (event as CustomEvent<{ paneId: string }>).detail?.paneId;
+    if (paneId) listener(paneId);
+  };
+  window.addEventListener(SHELL_EXIT_EVENT, onExit);
+  return () => window.removeEventListener(SHELL_EXIT_EVENT, onExit);
 }
 
 export function terminalSessionId(paneId: string, sshTarget?: string): string {
@@ -1245,7 +1255,7 @@ function getSession(id: string, cwdFrom?: string[], sshTarget?: string, paneId =
       }
       writeSessionData(id, data);
     });
-    b.onExit((reason) => {
+    b.onExit((reason, exit) => {
       if (agentActivities.has(id)) setAgentActivity(id, reason ? "error" : "done");
       if (sshTarget) {
         session.ended = true;
@@ -1261,13 +1271,25 @@ function getSession(id: string, cwdFrom?: string[], sshTarget?: string, paneId =
       }
       // A truthy reason means the WebSocket itself couldn't connect, which
       // already exhausted its own retry budget (see WebSocketBackend) before
-      // giving up — not worth immediately repeating that losing battle. Only
-      // a natural shell exit (no reason) is auto-respawned.
+      // giving up — not worth immediately repeating that losing battle, and
+      // the shell never ran, so there is nothing to conclude about intent.
       if (reason) {
         term.write(`\r\n\x1b[2m[session ended: ${reason}]\x1b[0m\r\n`);
         return;
       }
-      if (Date.now() - session.spawnedAt > RESTART_HEALTHY_MS) session.restartAttempts = 0;
+      const aliveMs = Date.now() - session.spawnedAt;
+      if (aliveMs > RESTART_HEALTHY_MS) session.restartAttempts = 0;
+      // The user ended this shell on purpose (`exit`, Ctrl+D), so take the pane
+      // with it the way every other terminal does. Only the pane's FOREGROUND
+      // session gets that treatment: a local shell idling behind a visible SSH
+      // session must stay alive, or switching back would land on a dead pane.
+      if (
+        shellExitDisposition(exit, aliveMs) === "close-pane" &&
+        activeSessionByPane.get(paneId) === id
+      ) {
+        window.dispatchEvent(new CustomEvent(SHELL_EXIT_EVENT, { detail: { paneId } }));
+        return;
+      }
       if (session.restartAttempts >= MAX_AUTO_RESTARTS) {
         term.write(`\r\n\x1b[2m[session ended]\x1b[0m\r\n`);
         return;

--- a/apps/web/src/terminal/shellExit.test.ts
+++ b/apps/web/src/terminal/shellExit.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { SHELL_EXIT_CLOSE_CODE, encodeShellExit, parseShellExit } from "@termany/core";
+import { RESTART_HEALTHY_MS, shellExitDisposition } from "./shellExit";
+
+const LONG_LIVED = RESTART_HEALTHY_MS + 1;
+const JUST_SPAWNED = 120;
+
+test("a shell the user exited on purpose closes its pane", () => {
+  // `exit` / Ctrl+D at an interactive prompt, last command succeeded.
+  assert.equal(shellExitDisposition({ exitCode: 0 }, LONG_LIVED), "close-pane");
+});
+
+test("Ctrl+D after a failed command still closes the pane", () => {
+  // Both bash and zsh exit with the LAST command's status on EOF, so a
+  // deliberate Ctrl+D after `grep` finds nothing arrives here as code 1.
+  // Judging that by exit code alone would respawn the pane the user just
+  // asked to close — which is the whole bug this logic exists to fix.
+  assert.equal(shellExitDisposition({ exitCode: 1 }, LONG_LIVED), "close-pane");
+  assert.equal(shellExitDisposition({ exitCode: 127 }, LONG_LIVED), "close-pane");
+});
+
+test("a shell that dies instantly restarts instead of closing the pane", () => {
+  // The crash-loop case the auto-restart was built for: a bad rc file or a
+  // missing shell binary kills every spawn within milliseconds.
+  assert.equal(shellExitDisposition({ exitCode: 1 }, JUST_SPAWNED), "restart");
+  assert.equal(shellExitDisposition({ exitCode: 0 }, JUST_SPAWNED), "restart");
+});
+
+test("a shell killed by a signal restarts however long it lived", () => {
+  // Segfault, OOM killer, `kill -9` — never something the user asked for, so
+  // the pane stays and gets a fresh shell.
+  assert.equal(shellExitDisposition({ exitCode: 0, signal: 9 }, LONG_LIVED), "restart");
+  assert.equal(shellExitDisposition({ exitCode: 139, signal: 11 }, LONG_LIVED), "restart");
+});
+
+test("signal 0 is 'not signalled', not signal number zero", () => {
+  // node-pty reports 0/undefined for a plain exit; only a real signal number
+  // counts as an abnormal kill.
+  assert.equal(shellExitDisposition({ exitCode: 0, signal: 0 }, LONG_LIVED), "close-pane");
+  assert.equal(shellExitDisposition({ exitCode: 0, signal: undefined }, LONG_LIVED), "close-pane");
+});
+
+test("an exit with no payload restarts rather than closing the pane", () => {
+  // The socket closed without the server reporting how the shell ended (server
+  // shutdown, or a second connection displacing this one). Closing a pane is
+  // destructive and irreversible, so it needs positive evidence — without it,
+  // fall back to the pre-existing auto-restart behaviour.
+  assert.equal(shellExitDisposition(undefined, LONG_LIVED), "restart");
+  assert.equal(shellExitDisposition(undefined, JUST_SPAWNED), "restart");
+});
+
+test("the healthy-uptime boundary is exclusive", () => {
+  assert.equal(shellExitDisposition({ exitCode: 0 }, RESTART_HEALTHY_MS), "restart");
+  assert.equal(shellExitDisposition({ exitCode: 0 }, RESTART_HEALTHY_MS + 1), "close-pane");
+});
+
+// --- the wire format the disposition above is fed from ----------------------
+
+test("an exit status survives the round trip through a close frame", () => {
+  for (const exit of [{ exitCode: 0 }, { exitCode: 1 }, { exitCode: 137, signal: 9 }]) {
+    const encoded = encodeShellExit(exit);
+    assert.ok(
+      Buffer.byteLength(encoded, "utf8") <= 123,
+      "close reasons are capped at 123 bytes by the WebSocket spec"
+    );
+    assert.deepEqual(parseShellExit(SHELL_EXIT_CLOSE_CODE, encoded), {
+      exitCode: exit.exitCode,
+      signal: exit.signal ?? 0,
+    });
+  }
+});
+
+test("only the shell-exit close code carries a status", () => {
+  const payload = encodeShellExit({ exitCode: 0 });
+  // 1000/1001/1006 are ordinary transport closes — the server shutting down, a
+  // newer connection taking over, a dropped socket. None of them says anything
+  // about how the shell ended, so none may be read as a clean exit.
+  assert.equal(parseShellExit(1000, payload), undefined);
+  assert.equal(parseShellExit(1006, ""), undefined);
+  assert.equal(parseShellExit(1001, payload), undefined);
+});
+
+test("a malformed payload reads as unknown rather than as a clean exit", () => {
+  // Anything that would otherwise default exitCode to 0 must not: "unknown"
+  // keeps the pane, "clean" destroys it.
+  for (const bad of ["", "not json", "{}", "null", "[]", '{"exitCode":"0"}']) {
+    assert.equal(parseShellExit(SHELL_EXIT_CLOSE_CODE, bad), undefined, `payload: ${bad}`);
+  }
+});
+
+test("a decoded close frame drives the disposition end to end", () => {
+  const decode = (exitCode: number, signal?: number) =>
+    parseShellExit(SHELL_EXIT_CLOSE_CODE, encodeShellExit({ exitCode, signal }));
+  assert.equal(shellExitDisposition(decode(0), LONG_LIVED), "close-pane");
+  assert.equal(shellExitDisposition(decode(1), LONG_LIVED), "close-pane");
+  // A SIGKILL reports exitCode 0 (verified against a real PTY in
+  // apps/server/tests/shellExit.test.ts) — indistinguishable from a graceful
+  // exit unless the signal survives the trip.
+  assert.equal(shellExitDisposition(decode(0, 9), LONG_LIVED), "restart");
+});

--- a/apps/web/src/terminal/shellExit.ts
+++ b/apps/web/src/terminal/shellExit.ts
@@ -1,0 +1,52 @@
+import type { ShellExit } from "@termany/core";
+
+/**
+ * How long a shell has to survive before we believe it started successfully.
+ * Under this, a death is a launch failure (bad rc file, missing binary) rather
+ * than anything the user did.
+ */
+export const RESTART_HEALTHY_MS = 3000;
+
+/**
+ * Cap on consecutive fast respawns, so a shell that dies on every launch can't
+ * spin forever. Reset once a shell lives past RESTART_HEALTHY_MS, which keeps
+ * the cap meaning "5 failures in a row" rather than "5 ever".
+ */
+export const MAX_AUTO_RESTARTS = 5;
+
+export type ShellExitDisposition = "close-pane" | "restart";
+
+/**
+ * Decide what a dead shell should do to its pane.
+ *
+ * Every mainstream terminal closes the pane when its shell exits, and that is
+ * what a user pressing Ctrl+D is asking for. Respawning in place (what this app
+ * did unconditionally before) makes the pane un-closable from the keyboard and
+ * surprises anyone with terminal muscle memory.
+ *
+ * The tempting test — "exit code 0 means the user meant it" — does not work:
+ * both bash and zsh exit with the LAST COMMAND'S status on EOF, so Ctrl+D after
+ * a `grep` that matched nothing arrives as code 1. Judging by exit code alone
+ * would respawn exactly the pane the user just asked to close.
+ *
+ * So the signal we key on is *how* the shell died, not what it returned:
+ *
+ *   - killed by a signal (segfault, OOM, `kill -9`) -> never user intent
+ *   - dead within RESTART_HEALTHY_MS of spawning    -> launch failure, not intent
+ *   - anything else                                 -> it ran, then ended on its
+ *                                                      own, i.e. the user did it
+ *
+ * `exit` being undefined means the socket closed without the server saying how
+ * (its own shutdown, a newer connection displacing this one, an older server).
+ * Closing a pane is destructive and irreversible, so it needs positive
+ * evidence — without any, fall back to the historical restart behaviour.
+ */
+export function shellExitDisposition(
+  exit: ShellExit | undefined,
+  aliveMs: number
+): ShellExitDisposition {
+  if (!exit) return "restart";
+  if (exit.signal) return "restart"; // 0/undefined == "not signalled"
+  if (aliveMs <= RESTART_HEALTHY_MS) return "restart";
+  return "close-pane";
+}

--- a/packages/core/src/backend.ts
+++ b/packages/core/src/backend.ts
@@ -17,8 +17,12 @@ export interface ITerminalBackend {
   write(data: string): void;
   /** Tell the PTY the new viewport size. */
   resize(cols: number, rows: number): void;
-  /** Register a callback for when the underlying session ends. */
-  onExit(cb: (reason?: string) => void): void;
+  /**
+   * Register a callback for when the underlying session ends. `reason` is set
+   * only when the transport itself failed; `exit` carries how the shell ended
+   * when the backend could observe it (see ShellExit).
+   */
+  onExit(cb: (reason?: string, exit?: ShellExit) => void): void;
   /** Tear down the connection / session. */
   dispose(): void;
 }
@@ -27,3 +31,51 @@ export interface ITerminalBackend {
 export type ClientMessage =
   | { type: "input"; data: string }
   | { type: "resize"; cols: number; rows: number };
+
+/**
+ * How a shell process ended, as observed by the PTY host.
+ *
+ * Distinguishing "the user typed `exit`" from "the shell crashed" is what lets
+ * the UI close a pane in the first case and keep it alive in the second, so it
+ * has to survive the trip to the frontend. It rides on the WebSocket CLOSE
+ * frame rather than the data stream: every server -> client text frame is raw
+ * terminal output, and any in-band sentinel could collide with bytes a shell
+ * legitimately printed.
+ */
+export interface ShellExit {
+  exitCode: number;
+  /** A real signal number when the OS killed the shell; 0/absent for a plain exit. */
+  signal?: number;
+}
+
+/**
+ * Close code stamped on the CLOSE frame that carries a ShellExit payload.
+ * 4000-4999 is the range WebSocket reserves for private application use, so it
+ * can never be confused with a protocol-level close (1000-2999) — which is the
+ * point: only THIS code means "the shell ended and here is how".
+ */
+export const SHELL_EXIT_CLOSE_CODE = 4000;
+
+/** Serialize a ShellExit for the CLOSE frame's reason field. */
+export function encodeShellExit(exit: ShellExit): string {
+  // Close reasons are capped at 123 UTF-8 bytes; this JSON is ~30 at worst.
+  return JSON.stringify({ exitCode: exit.exitCode, signal: exit.signal ?? 0 });
+}
+
+/**
+ * Recover a ShellExit from a CLOSE frame, or undefined when the close says
+ * nothing about the shell (an old server, a transport-level close, a truncated
+ * reason). Callers must treat undefined as "unknown", never as a clean exit.
+ */
+export function parseShellExit(code: number, reason: string): ShellExit | undefined {
+  if (code !== SHELL_EXIT_CLOSE_CODE || !reason) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(reason);
+    if (!parsed || typeof parsed !== "object") return undefined;
+    const { exitCode, signal } = parsed as { exitCode?: unknown; signal?: unknown };
+    if (typeof exitCode !== "number" || !Number.isFinite(exitCode)) return undefined;
+    return { exitCode, signal: typeof signal === "number" ? signal : 0 };
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,2 +1,3 @@
-export type { ITerminalBackend, ClientMessage } from "./backend.js";
+export type { ITerminalBackend, ClientMessage, ShellExit } from "./backend.js";
+export { SHELL_EXIT_CLOSE_CODE, encodeShellExit, parseShellExit } from "./backend.js";
 export { WebSocketBackend } from "./ws-backend.js";

--- a/packages/core/src/ws-backend.ts
+++ b/packages/core/src/ws-backend.ts
@@ -1,4 +1,4 @@
-import type { ClientMessage, ITerminalBackend } from "./backend.js";
+import { parseShellExit, type ClientMessage, type ITerminalBackend, type ShellExit } from "./backend.js";
 
 // The bundled server boots in parallel with the webview and can lose the race
 // by a few hundred ms — retry the INITIAL connection instead of declaring the
@@ -26,7 +26,7 @@ export class WebSocketBackend implements ITerminalBackend {
   private retryTimer: ReturnType<typeof setTimeout> | undefined;
   private outbox: string[] = [];
   private dataCb?: (data: string) => void;
-  private exitCb?: (reason?: string) => void;
+  private exitCb?: (reason?: string, exit?: ShellExit) => void;
 
   constructor(url: string, params?: Record<string, string | undefined>) {
     const wsUrl = new URL(url);
@@ -49,18 +49,22 @@ export class WebSocketBackend implements ITerminalBackend {
     this.ws.onmessage = (e) => {
       if (typeof e.data === "string") this.dataCb?.(e.data);
     };
-    this.ws.onclose = () => {
+    this.ws.onclose = (event) => {
       this.open = false;
       if (this.disposed) return;
       if (!this.everOpened && this.attempts < MAX_CONNECT_ATTEMPTS) {
         this.retryTimer = setTimeout(() => this.connect(), RETRY_DELAY_MS * this.attempts);
         return;
       }
-      this.exitCb?.(
-        this.everOpened
-          ? undefined
-          : `unable to connect to Termany PTY server at ${this.url.host}`
-      );
+      if (!this.everOpened) {
+        this.exitCb?.(`unable to connect to Termany PTY server at ${this.url.host}`);
+        return;
+      }
+      // A close AFTER the socket opened is a real session end. The server
+      // stamps the frame with how the shell died when it knows; anything else
+      // (its own shutdown, a newer connection displacing us) arrives without a
+      // payload and stays "unknown" to the caller.
+      this.exitCb?.(undefined, parseShellExit(event.code, event.reason));
     };
   }
 
@@ -68,7 +72,7 @@ export class WebSocketBackend implements ITerminalBackend {
     this.dataCb = cb;
   }
 
-  onExit(cb: (reason?: string) => void) {
+  onExit(cb: (reason?: string, exit?: ShellExit) => void) {
     this.exitCb = cb;
   }
 


### PR DESCRIPTION
## 问题

按 Ctrl+D（或输入 `exit`）退出 shell 后，pane 不会关闭，而是原地起一个新 shell。结果是**没有任何办法用键盘关掉一个 pane**，和 iTerm2 / Terminal.app / Windows Terminal / kitty / tmux / VS Code 的行为都不一致。

这个原地复活是 v0.1.14（7e18f25）有意加的，为了解决「shell 退出后 pane 变成一具死尸」。那个目标保留，只是把适用范围收窄到它真正要解决的场景。

## 思路

**exit code 0 说明是用户主动退出，就不去复活它，这样能跟其他主流终端保持行为一致；如果是出错崩溃了，退出后还是会复活，原来的功能没有丢弃。**

不过实现的时候发现，**光看 exit code 判断不出「是不是用户主动退出」**，实测：

```
$ printf 'false\n' | zsh -i   →  exit=1     # Ctrl+D 前跑过失败命令
$ kill -9 $$                  →  exit=0, signal=9   # 崩溃反而是 0
```

bash 和 zsh 在 EOF 时都返回**最后一条命令的状态**。所以 `grep` 没匹配到（返回 1）、测试挂了、build 失败之后按 Ctrl+D，退出码是非 0 —— 按字面规则会继续复活，正好还是这个 bug。反过来被 SIGKILL 杀死时 exitCode 是 0，会被误判成「主动退出」而关掉 pane。

所以真正的判据是**怎么死的**，而不是返回了什么：

| 退出方式 | 行为 |
|---|---|
| Ctrl+D / `exit`（活过 3 秒） | 关闭 pane |
| `grep` 无匹配后 Ctrl+D（code 1） | 关闭 pane |
| 启动 3 秒内就死（坏 rc 文件、缺二进制） | 复活（上限 5 次） |
| 被信号杀死（段错误 / OOM / `kill -9`） | 复活 |
| 退出状态未知 | 复活（关 pane 不可逆，必须有正面证据） |

「3 秒内就死」正是原 commit 注释里点名的 crash loop 场景，重启上限也原样保留。

## 实现

- 退出状态通过 WebSocket **CLOSE 帧**传给前端（close code 4000 + JSON reason），不走数据流 —— server→client 的文本帧全是原始终端输出，任何带内标记都可能和 shell 真实打印的内容撞车。
- 判定逻辑独立成 `apps/web/src/terminal/shellExit.ts`，纯函数、可测。
- 只有 pane 的**前台** session 会关闭 pane：SSH 会话在前台时，后面挂着的本地 shell 退出仍然复活，否则切回来会落到一个死 pane 上。
- `closeLeaf` 改成定位 leaf 自己所在的 tab，不再假设是当前活动 tab —— shell 可能在后台 tab 里退出，旧的查找会在已经 dispose 掉 session 之后错过它。
- SSH 会话的行为完全没动（仍然是「按 Enter 重连」）。

## 验证

- **单元测试**（`apps/web/src/terminal/shellExit.test.ts`，11 项）：判定逻辑各分支 + close 帧编解码，含畸形 payload 必须读成「未知」而不是「干净退出」。
- **端到端测试**（`apps/server/tests/shellExit.test.ts`，3 项）：真实 server + 真实 PTY，确认 `kill -9` 报 `{exitCode: 0, signal: 9}`、`false` 后 EOF 报 `{exitCode: 1}`。跑在隔离的 HOME 下，不碰 `~/.termany`。
- **真实 UI**（Playwright 驱动）：Ctrl+D 在命令成功和失败两种情况下都关闭 pane；`kill -9 $$` 仍然原地复活并打印 `[session ended — starting a new shell]`，新 shell 可正常执行命令。
- `npm run build:web` 通过；web 22 项测试、server 26 项测试全绿。

## 注意

单 pane 时按 Ctrl+D 会得到一个新的空标签页 —— 这是 app 「至少保留一个 tab」的既有约束，和 ⌘W 的行为一致。多 pane / 多 tab 时才能看到真正的关闭效果。
