### PR TITLE
fix: own the IME commit on Linux WebKitGTK so Fcitx5 text lands once

### DIFF
--- a/apps/web/src/terminal/manager.ts
+++ b/apps/web/src/terminal/manager.ts
@@ -16,6 +16,7 @@ import {
 } from "./agentActivityPrompt";
 import { registerLocalPathLinks } from "./localLinks";
 import { registerWebLinks } from "./webLinks";
+import { fixWebkitGtkImeComposition } from "./webkitGtkIme";
 
 /**
  * The terminal session registry.
@@ -1560,6 +1561,7 @@ export function attachSession(
     }
     fixWebkitImeDirectInsert(s.term);
     fixAbandonedImeFinalize(s.term);
+    fixWebkitGtkImeComposition(s.term, imeLog);
     traceImeEvents(s.term);
     s.term.onScroll(() => {
       const scrollState = readScrollState(s.term);

--- a/apps/web/src/terminal/webkitGtkIme.test.ts
+++ b/apps/web/src/terminal/webkitGtkIme.test.ts
@@ -1,0 +1,268 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { COMMIT_ECHO_MS, createGtkImeCommitMachine } from "./webkitGtkIme";
+
+interface FakeEvent {
+  keyCode: number;
+  inputType: string;
+  data: string | null;
+  prevented: boolean;
+  stopped: boolean;
+  preventDefault(): void;
+  stopPropagation(): void;
+}
+
+function fakeEvent(props: Partial<Pick<FakeEvent, "keyCode" | "inputType" | "data">> = {}): FakeEvent {
+  const e: FakeEvent = {
+    keyCode: 0,
+    inputType: "",
+    data: null,
+    prevented: false,
+    stopped: false,
+    preventDefault() {
+      e.prevented = true;
+    },
+    stopPropagation() {
+      e.stopped = true;
+    },
+    ...props,
+  };
+  return e;
+}
+
+function makeHarness() {
+  const commits: string[] = [];
+  let clears = 0;
+  let now = 1000;
+  const timers = new Map<number, () => void>();
+  let nextTimer = 1;
+  const machine = createGtkImeCommitMachine({
+    commit: (data) => commits.push(data),
+    clearTextarea: () => clears++,
+    setTimer: (fn) => {
+      const id = nextTimer++;
+      timers.set(id, fn);
+      return id;
+    },
+    clearTimer: (id) => timers.delete(id),
+    now: () => now,
+  });
+  return {
+    machine,
+    commits,
+    get clears() {
+      return clears;
+    },
+    advance(ms: number) {
+      now += ms;
+    },
+    firePendingTimers() {
+      const fns = [...timers.values()];
+      timers.clear();
+      for (const fn of fns) fn();
+    },
+    get pendingTimerCount() {
+      return timers.size;
+    },
+  };
+}
+
+/** Feed the preedit phase of a composition: 229 keydowns + composition/input noise. */
+function feedPreedit(h: ReturnType<typeof makeHarness>, updates: string[]) {
+  h.machine.keydown(fakeEvent({ keyCode: 229 }));
+  h.machine.compositionstart(fakeEvent({ data: "" }));
+  for (const text of updates) {
+    h.machine.keydown(fakeEvent({ keyCode: 229 }));
+    h.machine.beforeinput(fakeEvent({ inputType: "insertCompositionText", data: text }));
+    h.machine.input(fakeEvent({ inputType: "insertCompositionText", data: text }));
+    h.machine.compositionupdate(fakeEvent({ data: text }));
+  }
+}
+
+test("commits a Fcitx5 phrase exactly once via the final beforeinput", () => {
+  const h = makeHarness();
+  const key229 = fakeEvent({ keyCode: 229 });
+  h.machine.keydown(key229);
+  assert.equal(key229.stopped, true, "xterm's keyCode-229 textarea-diff fallback must be blocked");
+  assert.equal(key229.prevented, false, "the keydown itself must stay native so the IME works");
+
+  const start = fakeEvent({ data: "" });
+  h.machine.compositionstart(start);
+  assert.equal(start.stopped, true, "xterm's CompositionHelper must never enter composition");
+
+  const preedit = fakeEvent({ inputType: "insertCompositionText", data: "jia" });
+  h.machine.beforeinput(preedit);
+  assert.equal(preedit.stopped, true);
+  assert.equal(preedit.prevented, false, "preedit must still mutate the textarea natively");
+  h.machine.input(fakeEvent({ inputType: "insertCompositionText", data: "jia" }));
+  h.machine.compositionupdate(fakeEvent({ data: "jia" }));
+
+  const end = fakeEvent({ data: "甲乙丙" });
+  h.machine.compositionend(end);
+  assert.equal(end.stopped, true);
+  assert.deepEqual(h.commits, [], "nothing sent yet — the commit rides the next beforeinput");
+
+  const commit = fakeEvent({ inputType: "insertText", data: "甲乙丙" });
+  h.machine.beforeinput(commit);
+  assert.equal(commit.prevented, true, "native insertion is ours to cancel");
+  assert.equal(commit.stopped, true);
+  assert.deepEqual(h.commits, ["甲乙丙"]);
+  assert.ok(h.clears >= 1, "the hidden textarea is wiped after the commit");
+  assert.equal(h.pendingTimerCount, 0, "fallback timer cancelled once the commit lands");
+
+  // WebKitGTK can still fire the follow-up input event despite preventDefault.
+  const echo = fakeEvent({ inputType: "insertText", data: "甲乙丙" });
+  h.machine.input(echo);
+  assert.equal(echo.stopped, true, "the echoed input event must not reach xterm");
+  assert.deepEqual(h.commits, ["甲乙丙"], "still exactly one copy");
+});
+
+test("falls back to compositionend data when the commit beforeinput has no data", () => {
+  const h = makeHarness();
+  feedPreedit(h, ["ni", "nihao"]);
+  h.machine.compositionend(fakeEvent({ data: "你好" }));
+  const commit = fakeEvent({ inputType: "insertText", data: null });
+  h.machine.beforeinput(commit);
+  assert.equal(commit.prevented, true);
+  assert.deepEqual(h.commits, ["你好"]);
+});
+
+test("flushes the pending commit when no beforeinput ever follows", () => {
+  const h = makeHarness();
+  feedPreedit(h, ["bing"]);
+  h.machine.compositionend(fakeEvent({ data: "丙" }));
+  assert.deepEqual(h.commits, []);
+  assert.equal(h.pendingTimerCount, 1);
+  h.firePendingTimers();
+  assert.deepEqual(h.commits, ["丙"]);
+  assert.ok(h.clears >= 1);
+  h.firePendingTimers();
+  assert.deepEqual(h.commits, ["丙"], "the timer path fires at most once");
+});
+
+test("flushes before a real key so Enter lands after the committed text", () => {
+  const h = makeHarness();
+  feedPreedit(h, ["hao"]);
+  h.machine.compositionend(fakeEvent({ data: "好" }));
+
+  const enter = fakeEvent({ keyCode: 13 });
+  h.machine.keydown(enter);
+  assert.deepEqual(h.commits, ["好"], "text must be committed before Enter reaches xterm");
+  assert.equal(enter.stopped, false, "Enter itself passes through to xterm");
+
+  // The engine's commit events straggle in after our flush: swallow, don't resend.
+  const late = fakeEvent({ inputType: "insertText", data: "好" });
+  h.machine.beforeinput(late);
+  assert.equal(late.prevented, true);
+  assert.equal(late.stopped, true);
+  const lateInput = fakeEvent({ inputType: "insertText", data: "好" });
+  h.machine.input(lateInput);
+  assert.equal(lateInput.stopped, true);
+  assert.deepEqual(h.commits, ["好"]);
+});
+
+test("flushes an unsent commit when the next composition starts", () => {
+  const h = makeHarness();
+  feedPreedit(h, ["jia"]);
+  h.machine.compositionend(fakeEvent({ data: "甲" }));
+  feedPreedit(h, ["yi"]);
+  assert.deepEqual(h.commits, ["甲"], "previous word flushed before the new preedit opens");
+  h.machine.compositionend(fakeEvent({ data: "乙" }));
+  h.machine.beforeinput(fakeEvent({ inputType: "insertText", data: "乙" }));
+  assert.deepEqual(h.commits, ["甲", "乙"]);
+});
+
+test("leaves plain ASCII typing alone", () => {
+  const h = makeHarness();
+  const key = fakeEvent({ keyCode: 65 });
+  h.machine.keydown(key);
+  assert.equal(key.stopped, false);
+  const before = fakeEvent({ inputType: "insertText", data: "a" });
+  h.machine.beforeinput(before);
+  assert.equal(before.prevented, false);
+  assert.equal(before.stopped, false);
+  const input = fakeEvent({ inputType: "insertText", data: "a" });
+  h.machine.input(input);
+  assert.equal(input.stopped, false);
+  assert.deepEqual(h.commits, [], "xterm owns ordinary typing");
+});
+
+test("leaves paste alone", () => {
+  const h = makeHarness();
+  const before = fakeEvent({ inputType: "insertFromPaste", data: "ls -la" });
+  h.machine.beforeinput(before);
+  assert.equal(before.prevented, false);
+  assert.equal(before.stopped, false);
+  assert.deepEqual(h.commits, []);
+});
+
+test("sends nothing for a cancelled composition", () => {
+  const h = makeHarness();
+  feedPreedit(h, ["n"]);
+  h.machine.compositionend(fakeEvent({ data: "" }));
+  h.firePendingTimers();
+  assert.deepEqual(h.commits, []);
+});
+
+test("treats a stray insertText during preedit as composition noise, not a commit", () => {
+  const h = makeHarness();
+  h.machine.compositionstart(fakeEvent({ data: "" }));
+  const stray = fakeEvent({ inputType: "insertText", data: "x" });
+  h.machine.beforeinput(stray);
+  assert.equal(stray.stopped, true, "hidden from xterm — its helper thinks it is not composing");
+  assert.equal(stray.prevented, false, "but the native mutation stays: it is the IME's preedit");
+  assert.deepEqual(h.commits, []);
+  h.machine.compositionend(fakeEvent({ data: "x" }));
+  h.machine.beforeinput(fakeEvent({ inputType: "insertText", data: "x" }));
+  assert.deepEqual(h.commits, ["x"]);
+});
+
+test("swallows only the immediate echo, not identical text typed later", () => {
+  const h = makeHarness();
+  feedPreedit(h, ["abc"]);
+  h.machine.compositionend(fakeEvent({ data: "abc" }));
+  h.machine.beforeinput(fakeEvent({ inputType: "insertText", data: "abc" }));
+  assert.deepEqual(h.commits, ["abc"]);
+
+  h.advance(COMMIT_ECHO_MS + 1);
+  const later = fakeEvent({ inputType: "insertText", data: "abc" });
+  h.machine.beforeinput(later);
+  assert.equal(later.prevented, false, "past the echo window this is ordinary input for xterm");
+  assert.equal(later.stopped, false);
+  assert.deepEqual(h.commits, ["abc"], "the machine does not commit it either — xterm will");
+});
+
+test("accepts a commit-shaped input event when beforeinput never fires", () => {
+  const h = makeHarness();
+  feedPreedit(h, ["ding"]);
+  h.machine.compositionend(fakeEvent({ data: "丁" }));
+  const input = fakeEvent({ inputType: "insertText", data: "丁" });
+  h.machine.input(input);
+  assert.equal(input.stopped, true);
+  assert.deepEqual(h.commits, ["丁"]);
+  assert.equal(h.pendingTimerCount, 0);
+  h.firePendingTimers();
+  assert.deepEqual(h.commits, ["丁"]);
+});
+
+test("treats WebKit's insertFromComposition commit shape like insertText", () => {
+  const h = makeHarness();
+  feedPreedit(h, ["wu"]);
+  h.machine.compositionend(fakeEvent({ data: "戊" }));
+  const commit = fakeEvent({ inputType: "insertFromComposition", data: "戊" });
+  h.machine.beforeinput(commit);
+  assert.equal(commit.prevented, true);
+  assert.deepEqual(h.commits, ["戊"]);
+});
+
+test("compositionupdate alone still marks the machine as composing", () => {
+  const h = makeHarness();
+  // Some engines skip compositionstart entirely.
+  const update = fakeEvent({ data: "j" });
+  h.machine.compositionupdate(update);
+  assert.equal(update.stopped, true);
+  const stray = fakeEvent({ inputType: "insertText", data: "j" });
+  h.machine.beforeinput(stray);
+  assert.equal(stray.stopped, true);
+  assert.deepEqual(h.commits, []);
+});

--- a/apps/web/src/terminal/webkitGtkIme.ts
+++ b/apps/web/src/terminal/webkitGtkIme.ts
@@ -1,0 +1,226 @@
+import type { Terminal } from "@xterm/xterm";
+
+/**
+ * Linux WebKitGTK IME fix (issue #22): with Fcitx5/Rime, committed CJK
+ * phrases arrive duplicated or interleaved with stale preedit fragments
+ * ("甲乙丙" becomes "甲乙甲乙丙甲乙丙…") while ASCII typing is fine. PTY
+ * tracing showed the malformed chunks are produced in the frontend: xterm's
+ * CompositionHelper finalize and its keyCode-229 textarea-diff fallback both
+ * re-read the hidden textarea on deferred timers, and WebKitGTK updates that
+ * textarea on a different schedule than the engines those diffs were tuned
+ * for, so stale snapshots get (re)sent.
+ *
+ * The fix takes ownership of the whole composition on this engine. Every
+ * 229 keydown and composition/preedit event is stopped at document capture
+ * phase so xterm never runs any of its composition paths, and the committed
+ * text is delivered to the terminal exactly once by us: preferably by
+ * cancelling the engine's final `beforeinput` (`insertText` /
+ * `insertFromComposition`) and forwarding its data, with `compositionend`'s
+ * data as the fallback — flushed by a short timer, by the next real keydown
+ * (so Enter right after a commit lands *after* the text), or by the next
+ * composition starting. After a commit the hidden textarea is wiped and the
+ * engine's short-lived echo events for the same text are swallowed, leaving
+ * nothing stale behind for xterm to diff against.
+ *
+ * Tradeoff: xterm's inline preedit rendering is disabled on this engine
+ * (composition events never reach it); Fcitx5's own candidate window still
+ * shows the composition state.
+ */
+
+/** How long a commit waits for the engine's `beforeinput` after `compositionend`. */
+export const COMMIT_FLUSH_MS = 50;
+/** Window in which late echo events for an already-committed text are swallowed. */
+export const COMMIT_ECHO_MS = 150;
+
+interface StoppableEvent {
+  preventDefault(): void;
+  stopPropagation(): void;
+}
+export interface ImeKeyEventLike extends StoppableEvent {
+  keyCode: number;
+}
+export interface ImeCompositionEventLike extends StoppableEvent {
+  data: string | null;
+}
+export interface ImeInputEventLike extends StoppableEvent {
+  inputType: string;
+  data: string | null;
+}
+
+/** Injectable side effects — keeps the state machine testable without a DOM. */
+export interface GtkImeMachineHooks {
+  /** Deliver committed text to the terminal (term.input(data, true)). */
+  commit(data: string): void;
+  /** Wipe xterm's hidden textarea so stale preedit can't be re-read later. */
+  clearTextarea(): void;
+  setTimer(fn: () => void, ms: number): number;
+  clearTimer(id: number): void;
+  now(): number;
+  log?(line: string): void;
+}
+
+export function createGtkImeCommitMachine(hooks: GtkImeMachineHooks) {
+  let composing = false;
+  let pending: { fallback: string; timer: number } | null = null;
+  let echo: { data: string; at: number } | null = null;
+
+  const isCommitShape = (inputType: string) =>
+    inputType === "insertText" || inputType === "insertFromComposition";
+
+  function settle(data: string) {
+    if (data) {
+      hooks.commit(data);
+      echo = { data, at: hooks.now() };
+    }
+    hooks.clearTextarea();
+  }
+
+  function resolvePending(data: string | null, reason: string) {
+    if (!pending) return;
+    const { fallback, timer } = pending;
+    pending = null;
+    hooks.clearTimer(timer);
+    const text = data || fallback;
+    hooks.log?.(`gtk-ime:commit(${reason}) ${JSON.stringify(text)}`);
+    settle(text);
+  }
+
+  function isEcho(ev: ImeInputEventLike): boolean {
+    return (
+      echo !== null &&
+      isCommitShape(ev.inputType) &&
+      ev.data === echo.data &&
+      hooks.now() - echo.at <= COMMIT_ECHO_MS
+    );
+  }
+
+  return {
+    keydown(ev: ImeKeyEventLike) {
+      if (ev.keyCode === 229) {
+        // Hide the IME-processed keydown from xterm: its 229 fallback is the
+        // deferred textarea diff that emits the stale fragments. Propagation
+        // only — preventDefault would interfere with the IME itself.
+        ev.stopPropagation();
+        return;
+      }
+      // A real key while a commit is still pending (Enter straight after
+      // choosing a candidate): deliver the text now so it precedes the key.
+      if (pending) resolvePending(null, "keydown");
+    },
+    compositionstart(ev: ImeCompositionEventLike) {
+      if (pending) resolvePending(null, "compositionstart");
+      composing = true;
+      ev.stopPropagation();
+    },
+    compositionupdate(ev: ImeCompositionEventLike) {
+      // Some engines open a composition without compositionstart.
+      composing = true;
+      ev.stopPropagation();
+    },
+    compositionend(ev: ImeCompositionEventLike) {
+      composing = false;
+      ev.stopPropagation();
+      if (pending) resolvePending(null, "compositionend");
+      pending = {
+        fallback: ev.data ?? "",
+        timer: hooks.setTimer(() => resolvePending(null, "timeout"), COMMIT_FLUSH_MS),
+      };
+    },
+    beforeinput(ev: ImeInputEventLike) {
+      if (composing) {
+        // Preedit mutations: keep them native (the IME needs the textarea to
+        // update) but invisible to xterm, whose CompositionHelper was never
+        // told a composition is running.
+        ev.stopPropagation();
+        return;
+      }
+      if (pending && isCommitShape(ev.inputType)) {
+        ev.preventDefault();
+        ev.stopPropagation();
+        resolvePending(ev.data, "beforeinput");
+        return;
+      }
+      if (isEcho(ev)) {
+        ev.preventDefault();
+        ev.stopPropagation();
+        hooks.clearTextarea();
+      }
+    },
+    input(ev: ImeInputEventLike) {
+      if (composing) {
+        ev.stopPropagation();
+        return;
+      }
+      if (pending && isCommitShape(ev.inputType)) {
+        // Engine variant that commits without a beforeinput: the textarea has
+        // already mutated, so stop propagation and clean up after the fact.
+        ev.stopPropagation();
+        resolvePending(ev.data, "input");
+        return;
+      }
+      if (isEcho(ev)) {
+        ev.stopPropagation();
+        hooks.clearTextarea();
+      }
+    },
+  };
+}
+
+/**
+ * True only inside Linux WebKitGTK (Tauri's engine on Linux, also Epiphany).
+ * Mirrors isMacWebKit in manager.ts: pure-WebKit UA with no Chrome token,
+ * but on the Linux side of the platform split. Android WebViews are excluded
+ * explicitly — their UAs carry "Linux" too.
+ */
+export function isLinuxWebKitGtk(): boolean {
+  const ua = navigator.userAgent;
+  const isPureWebKit = ua.includes("AppleWebKit") && !/Chrome|Chromium|Edg\//.test(ua);
+  const isLinux = /Linux|X11/.test(navigator.platform) || /Linux|X11/.test(ua);
+  return isPureWebKit && isLinux && !ua.includes("Android");
+}
+
+export function fixWebkitGtkImeComposition(term: Terminal, log?: (line: string) => void) {
+  if (!isLinuxWebKitGtk() || !term.textarea) return;
+  const ta = term.textarea;
+  const machine = createGtkImeCommitMachine({
+    commit: (data) => term.input(data, true),
+    clearTextarea: () => {
+      ta.value = "";
+    },
+    setTimer: (fn, ms) => window.setTimeout(fn, ms),
+    clearTimer: (id) => window.clearTimeout(id),
+    now: () => performance.now(),
+    log,
+  });
+  const forTa =
+    <E extends Event>(handler: (ev: E) => void) =>
+    (ev: Event) => {
+      if (ev.target === ta) handler(ev as E);
+    };
+  // Document capture phase: ancestor capture listeners run before xterm's own
+  // textarea listeners regardless of attach order (same trick as
+  // fixAbandonedImeFinalize), so the machine gets to stop every event before
+  // xterm sees it.
+  document.addEventListener("keydown", forTa<KeyboardEvent>((ev) => machine.keydown(ev)), true);
+  document.addEventListener(
+    "compositionstart",
+    forTa<CompositionEvent>((ev) => machine.compositionstart(ev)),
+    true
+  );
+  document.addEventListener(
+    "compositionupdate",
+    forTa<CompositionEvent>((ev) => machine.compositionupdate(ev)),
+    true
+  );
+  document.addEventListener(
+    "compositionend",
+    forTa<CompositionEvent>((ev) => machine.compositionend(ev)),
+    true
+  );
+  document.addEventListener(
+    "beforeinput",
+    forTa<InputEvent>((ev) => machine.beforeinput(ev)),
+    true
+  );
+  document.addEventListener("input", forTa<InputEvent>((ev) => machine.input(ev)), true);
+}


### PR DESCRIPTION
Closes #22

## What

On Linux WebKitGTK (Tauri), Fcitx5/Rime commits could land in the terminal as duplicated or stale fragments (`echo 甲乙丙` becoming `甲乙甲乙丙甲乙丙…`) while ASCII typing was fine. This PR takes ownership of the whole IME composition on that engine, scoped by a new `isLinuxWebKitGtk()` check that mirrors the existing `isMacWebKit()` split, and delivers each committed phrase to the PTY exactly once.

## Why xterm misbehaves there

xterm has two paths that re-read its hidden textarea on deferred timers: `CompositionHelper`'s `compositionend` finalize, and the `keyCode 229` textarea-diff fallback. On WebKitGTK the 229 keydown and the textarea mutation arrive **before** the composition events, so the 0 ms diff timer fires while xterm still believes no composition is open and emits the preedit as ordinary input — the stale fragments the issue traced to the frontend, before the PTY boundary.

## How the fix works (`webkitGtkIme.ts`)

Following the approach validated by the issue reporter, at **document capture phase** (ancestor capture listeners always run before xterm's own textarea listeners):

- Stop propagation of `keyCode 229` keydowns and all composition/preedit events, so none of xterm's composition paths ever run (propagation only — the events stay native for the IME itself).
- Commit exactly once: prefer the engine's final `beforeinput` (`insertText` / `insertFromComposition`) — cancel it and forward its data via `term.input(data, true)` — with `compositionend`'s data retained as fallback.
- The fallback flushes on a short timer, on the next real keydown (so Enter pressed right after choosing a candidate lands *after* the text), or when the next composition starts.
- After a commit, wipe the hidden textarea and swallow the engine's short-lived echo events for the same text, so nothing stale remains to be diffed later.

Tradeoff: xterm's inline preedit rendering is disabled on this engine (it never sees composition events); Fcitx5's own candidate window still shows the composition state. macOS WebKit behavior is untouched — the two existing mac-only fixes and this one are mutually exclusive by platform check.

## Verification

- **13 new unit tests** (`webkitGtkIme.test.ts`) drive the commit state machine through the issue's event sequences: single commit via `beforeinput`, data fallback, timer flush, Enter-after-commit ordering, back-to-back compositions, cancelled composition, stray `insertText` during preedit, echo-window expiry, `insertFromComposition` shape, ASCII/paste passthrough. `npm -w @termany/web test`: 24/24 pass.
- **Browser smoke test** (Playwright, real xterm 5.5 + this fix, WebKitGTK-shaped synthetic event timing):
  - spoofed WebKitGTK identity + fix → exactly `甲乙丙`, once; Enter-after-commit yields `好` then `\r` in order; ASCII unaffected.
  - same sequence *without* the fix → stock xterm's 229 diff fires first and emits the stale preedit (`甲乙`) as its own chunk, confirming the sequence models the reported mechanism.
  - default macOS identity → `isLinuxWebKitGtk()` is false, fix stays dormant, typing unaffected.
- `tsc --noEmit` + vite build pass.

## Still needs on-device confirmation

I could not reproduce the real WebKitGTK/Fcitx5 environment here, so per the issue's notes this would benefit from on-device testing (Ubuntu 24.04/X11) with Japanese/Korean IMEs, full-width punctuation, paste, and rapid Enter-after-commit. @TechTerryDev if you can try this branch against your reproduction, that would be great — `?imedebug` overlays the fix's commit decisions (`gtk-ime:commit(...)` lines) for tracing.
