### PR TITLE
fix: 终端面板文字渲染错乱，需 resize 才能恢复（WebGL 字形图集共享导致）

### DIFF
--- a/apps/web/src/terminal/glyphAtlas.test.ts
+++ b/apps/web/src/terminal/glyphAtlas.test.ts
@@ -1,0 +1,165 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  ATLAS_REPAIR_MIN_INTERVAL_MS,
+  createGlyphAtlasRepairer,
+  onAtlasPagesMerged,
+} from "./glyphAtlas";
+
+/** A terminal stand-in that just counts the repairs it was asked to do. */
+function fakeTerminal() {
+  return { repairs: 0, clearTextureAtlas() { this.repairs++; } };
+}
+
+/** Manual clock + scheduler, so cooldown behaviour is asserted, not slept through. */
+function harness(terminals: { clearTextureAtlas(): void }[]) {
+  let clock = 0;
+  const queue: { run: () => void; at: number }[] = [];
+  const repairer = createGlyphAtlasRepairer({
+    terminals: () => terminals,
+    schedule: (run, delayMs) => queue.push({ run, at: clock + delayMs }),
+    now: () => clock,
+  });
+  return {
+    repairer,
+    queue,
+    advance(ms: number) {
+      clock += ms;
+      for (const task of queue.splice(0)) task.run();
+    },
+    get clock() {
+      return clock;
+    },
+  };
+}
+
+test("a burst of merge signals collapses into a single repair", () => {
+  // One page merge fires the event once per merged page (4) and again for every
+  // pane forwarding it off the shared atlas, so a single merge in an 8-pane
+  // window arrives here ~32 times. Repairing per signal would re-rasterise the
+  // whole atlas dozens of times over for one underlying event.
+  const term = fakeTerminal();
+  const h = harness([term]);
+
+  for (let i = 0; i < 32; i++) h.repairer.requestRepair();
+  assert.equal(h.queue.length, 1, "32 signals, one scheduled repair");
+
+  h.advance(0);
+  assert.equal(term.repairs, 1);
+});
+
+test("a merge repairs every pane, not just the one that noticed", () => {
+  // The whole point: panes share one atlas but each holds its own GPU copy of
+  // it. The merge invalidates all of them, and clearing the atlas from a single
+  // terminal would leave the others drawing with coordinates for a texture that
+  // no longer exists — trading one garbled pane for several.
+  const terms = [fakeTerminal(), fakeTerminal(), fakeTerminal()];
+  const h = harness(terms);
+
+  h.repairer.requestRepair();
+  h.advance(0);
+
+  for (const term of terms) assert.equal(term.repairs, 1);
+});
+
+test("the first merge repairs without waiting out a cooldown", () => {
+  const term = fakeTerminal();
+  const h = harness([term]);
+
+  h.repairer.requestRepair();
+  assert.equal(h.queue[0].at, 0, "nothing to cool down from yet");
+});
+
+test("a merge inside the cooldown is delayed, never dropped", () => {
+  // Dropping would be the easy rate limit and the wrong one: a dropped repair
+  // leaves that pane garbled until the *next* merge, which may be minutes away.
+  const term = fakeTerminal();
+  const h = harness([term]);
+
+  h.repairer.requestRepair();
+  h.advance(0);
+  assert.equal(term.repairs, 1);
+
+  h.advance(100);
+  h.repairer.requestRepair();
+  assert.equal(
+    h.queue[0].at,
+    ATLAS_REPAIR_MIN_INTERVAL_MS,
+    "held back to one repair per cooldown, measured from the last repair"
+  );
+
+  h.advance(ATLAS_REPAIR_MIN_INTERVAL_MS);
+  assert.equal(term.repairs, 2, "and it still happens");
+});
+
+test("a merge after the cooldown repairs immediately", () => {
+  const term = fakeTerminal();
+  const h = harness([term]);
+
+  h.repairer.requestRepair();
+  h.advance(0);
+  h.advance(ATLAS_REPAIR_MIN_INTERVAL_MS);
+
+  h.repairer.requestRepair();
+  assert.equal(h.queue[0].at, h.clock);
+});
+
+test("panes opened between the merge and the repair are repaired too", () => {
+  // The stale-texture damage is done at merge time to every pane sharing the
+  // atlas, and a pane attached moments later joins that same atlas — so the
+  // pane list is read when the repair runs, not when it was requested.
+  const terms = [fakeTerminal()];
+  const h = harness(terms);
+
+  h.repairer.requestRepair();
+  terms.push(fakeTerminal());
+  h.advance(0);
+
+  assert.deepEqual(terms.map((t) => t.repairs), [1, 1]);
+});
+
+test("a pane torn down mid-repair does not strand the rest", () => {
+  const before = fakeTerminal();
+  const after = fakeTerminal();
+  const closed = {
+    clearTextureAtlas() {
+      throw new Error("terminal disposed");
+    },
+  };
+  const h = harness([before, closed, after]);
+
+  h.repairer.requestRepair();
+  h.advance(0);
+
+  assert.equal(before.repairs, 1);
+  assert.equal(after.repairs, 1, "a dead pane must not eat the panes behind it");
+});
+
+// --- reading the merge signal off the addon ---------------------------------
+
+test("the merge signal is read off the addon despite missing typings", () => {
+  // @xterm/addon-webgl 0.18 emits onRemoveTextureAtlasCanvas — fired only from
+  // a page merge, which is exactly the moment glyph coordinates are rewritten —
+  // but leaves it out of its .d.ts.
+  const listeners: (() => void)[] = [];
+  const addon = {
+    onRemoveTextureAtlasCanvas: (listener: () => void) => {
+      listeners.push(listener);
+      return { dispose() {} };
+    },
+  };
+
+  let merges = 0;
+  const disposable = onAtlasPagesMerged(addon, () => merges++);
+  assert.ok(disposable, "subscribed");
+
+  for (const listener of listeners) listener();
+  assert.equal(merges, 1);
+});
+
+test("an addon without the merge signal degrades quietly", () => {
+  // A future addon version may rename or drop it; losing the repair is a
+  // rendering glitch, throwing here would cost the pane its GPU renderer.
+  assert.equal(onAtlasPagesMerged({}, () => {}), undefined);
+  assert.equal(onAtlasPagesMerged({ onRemoveTextureAtlasCanvas: 42 }, () => {}), undefined);
+});

--- a/apps/web/src/terminal/glyphAtlas.ts
+++ b/apps/web/src/terminal/glyphAtlas.ts
@@ -1,0 +1,123 @@
+/**
+ * Repairs the "wrong glyphs everywhere until you drag the split" corruption.
+ *
+ * xterm's WebGL renderer keeps rasterised glyphs in a texture atlas, and
+ * `CharAtlasCache` hands the SAME atlas to every terminal whose font, theme and
+ * device pixel ratio match — which here is every pane. Each pane still owns a
+ * separate WebGL context, though, so each holds its own GPU copy of every atlas
+ * page and re-uploads a page only when it looks stale. "Stale" is decided by
+ * comparing `atlas.pages[i].version` against the version this pane last
+ * uploaded *for index i*.
+ *
+ * That comparison is sound while pages only ever gain glyphs, because a page's
+ * version only counts up. But once the atlas hits its page budget it merges the
+ * four fullest pages into one double-sized page and deletes the originals,
+ * which shifts every later page down an index — and rewrites, in place, the
+ * texture coordinates of every glyph that moved. Now index i names a different
+ * page than it did at this pane's last upload, so the check compares two
+ * unrelated counters. They are small integers of similar magnitude, so sooner
+ * or later they match, the pane skips the upload it needed, and draws the
+ * merged layout's coordinates into a texture still holding the old page.
+ *
+ * The result is the giveaway symptom: not noise, but specific characters coming
+ * out as specific *other* glyphs — every character living on that one page —
+ * consistently, and staying that way. Panes that happened to render during the
+ * merge are fine; the idle ones rot.
+ *
+ * Resizing heals it because `handleResize` re-runs `_refreshCharAtlas`, whose
+ * `setAtlas` marks every page dirty and forces a full re-upload. Hence "drag
+ * the pane and it comes back".
+ *
+ * So watch for the merge and repair on purpose. `clearTextureAtlas` is xterm's
+ * documented remedy for a corrupt texture: it empties the shared atlas, bumps
+ * every page version and forces a full redraw. It has to be called on *every*
+ * pane — emptying the atlas from one terminal invalidates the coordinates the
+ * others are still drawing with, so repairing one pane alone would garble the
+ * neighbours it left behind.
+ */
+
+/** A disposable subscription, matching xterm's `IDisposable` structurally. */
+export interface AtlasSubscription {
+  dispose(): void;
+}
+
+/** The one method a repair needs; `Terminal` satisfies it. */
+export interface RepairableTerminal {
+  clearTextureAtlas(): void;
+}
+
+/**
+ * Floor on how often the atlas may be emptied. A repair throws away every
+ * rasterised glyph, so they have to be re-drawn as they reappear on screen —
+ * cheap once in a while, but merges arrive in clusters once the atlas is
+ * saturated, and without a floor a bad cluster would re-rasterise the visible
+ * screen over and over. Requests inside the window are delayed to its end, not
+ * discarded: a dropped repair leaves a pane garbled until the next merge.
+ */
+export const ATLAS_REPAIR_MIN_INTERVAL_MS = 2000;
+
+export interface GlyphAtlasRepairer {
+  /** Note that the shared atlas re-indexed its pages. Safe to call in bursts. */
+  requestRepair(): void;
+}
+
+export function createGlyphAtlasRepairer(options: {
+  /** Read when the repair runs, so panes attached in the meantime are covered. */
+  terminals: () => Iterable<RepairableTerminal>;
+  schedule?: (run: () => void, delayMs: number) => void;
+  now?: () => number;
+  minIntervalMs?: number;
+}): GlyphAtlasRepairer {
+  const schedule =
+    options.schedule ??
+    ((run: () => void, delayMs: number) => {
+      window.setTimeout(run, delayMs);
+    });
+  const now = options.now ?? (() => Date.now());
+  const minIntervalMs = options.minIntervalMs ?? ATLAS_REPAIR_MIN_INTERVAL_MS;
+
+  let pending = false;
+  let lastRepairAt = -Infinity;
+
+  const repair = () => {
+    pending = false;
+    lastRepairAt = now();
+    for (const terminal of options.terminals()) {
+      try {
+        terminal.clearTextureAtlas();
+      } catch {
+        // A pane can be disposed between the merge and this repair. The panes
+        // after it in the list still have a stale texture to fix.
+      }
+    }
+  };
+
+  return {
+    requestRepair() {
+      // The merge fires once per merged page and again through every pane
+      // forwarding the shared atlas's event, so one merge lands here dozens of
+      // times. Deferring also keeps the repair out of the render pass that
+      // triggered the merge, which is still mid-rasterisation.
+      if (pending) return;
+      pending = true;
+      schedule(repair, Math.max(0, minIntervalMs - (now() - lastRepairAt)));
+    },
+  };
+}
+
+type AtlasCanvasEvent = (listener: (canvas: HTMLCanvasElement) => void) => AtlasSubscription;
+
+/**
+ * Subscribe to the atlas page merge — the only event that says glyph
+ * coordinates were rewritten. `WebglAddon` emits `onRemoveTextureAtlasCanvas`
+ * (fired solely from the merge path) but omits it from its typings, so it is
+ * read off the instance and ignored if a future version stops emitting it.
+ */
+export function onAtlasPagesMerged(
+  addon: object,
+  listener: () => void
+): AtlasSubscription | undefined {
+  const { onRemoveTextureAtlasCanvas: event } = addon as { onRemoveTextureAtlasCanvas?: unknown };
+  if (typeof event !== "function") return undefined;
+  return (event as AtlasCanvasEvent).call(addon, () => listener());
+}

--- a/apps/web/src/terminal/manager.ts
+++ b/apps/web/src/terminal/manager.ts
@@ -24,6 +24,7 @@ import {
 import { forgetSessionUrls, noteSessionOutput } from "./servedUrls";
 import { registerWebLinks } from "./webLinks";
 import { fixWebkitGtkImeComposition } from "./webkitGtkIme";
+import { createGlyphAtlasRepairer, onAtlasPagesMerged } from "./glyphAtlas";
 
 /**
  * The terminal session registry.
@@ -167,6 +168,17 @@ export type TerminalScrollState = {
 };
 
 const sessions = new Map<string, Session>();
+
+/**
+ * Every pane's WebGL renderer shares one glyph texture atlas but keeps its own
+ * GPU copy of it, and the atlas silently re-indexes its pages when it merges
+ * them — leaving idle panes drawing with coordinates their texture no longer
+ * matches. See glyphAtlas.ts; this puts all of them back in sync.
+ */
+const glyphAtlasRepairer = createGlyphAtlasRepairer({
+  terminals: () => [...sessions.values()].filter((s) => s.opened).map((s) => s.term),
+});
+
 // A pane may keep a local shell and several SSH shells alive simultaneously.
 // Only one is mounted, but switching does not tear down the others.
 const activeSessionByPane = new Map<string, string>();
@@ -1606,6 +1618,10 @@ export function attachSession(
     try {
       const webgl = new WebglAddon();
       webgl.onContextLoss(() => webgl.dispose());
+      // A page merge in the shared atlas rewrites glyph coordinates out from
+      // under every pane that isn't rendering right now, which is what makes
+      // text come back as the wrong characters until the pane is resized.
+      onAtlasPagesMerged(webgl, () => glyphAtlasRepairer.requestRepair());
       s.term.loadAddon(webgl);
     } catch {
       /* no WebGL available — DOM renderer still works */


### PR DESCRIPTION
Fixes #28

## 解决了什么问题

#28 里 Mac 上中文乱码的截图就是这个 bug；当时怀疑是缺字体，装了 Nerd Font 后现象消失就先关了 issue，两天后又复现所以重新打开。装字体大概率只是碰巧延后了触发时机（atlas 撑满到开始合并页面需要时间），并不是根因——根因和字体无关，装不装字体都会触发，见下文。

Pane 中的文字偶尔会渲染成**错误的字符**——不是随机噪点，而是特定字符稳定显示成另一个特定字形（比如 `用` 变成 `报`，所有 `a`、`e` 变成细碎的图形），颜色往往也是错的。不会自己恢复，必须**拖动分割条把 pane resize 一下**才会变回正常。

长时间的 agent 会话、CJK 输出较多的场景最容易触发，因为这类内容最快把字形图集（glyph atlas）撑满。

## 为什么会这样

xterm 的 WebGL 渲染器把光栅化后的字形存在一张 texture atlas 里，`CharAtlasCache.acquireTextureAtlas()` 会把**同一个 atlas 实例**发给所有 font、theme、DPR 相同的 `Terminal`。`configEquals()` 里没有任何 per-terminal 字段，所以在 Termany 里就是**所有 pane 共享一份**。

但每个 pane 仍然有**独立的 WebGL context**，各自持有 atlas 每一页的 GPU 副本，只有在某一页「看起来过期」时才会重新上传：

```ts
// GlyphRenderer.render()
for (let i = 0; i < this._atlas.pages.length; i++) {
  if (this._atlas.pages[i].version !== this._atlasTextures[i].version) {
    this._bindAtlasPageTexture(gl, this._atlas, i);
  }
}
```

这个判断是**按页下标（index）比对版本号**。只要页面只会新增字形，这个判断就是对的——版本号只会递增。

但 atlas 页数超过上限后（`maxAtlasPages = min(32, MAX_TEXTURE_IMAGE_UNITS)`），`_createNewPage()` 会把最满的 4 页合并成一张双倍大小的新页，`_deletePage()` 删掉原来那 4 页——这会让**后面所有页的下标整体前移**，并且**原地改写**每个移动过的字形的 `texturePage` / `texturePosition` / `sizeClipSpace`。

移位之后，下标 `i` 指向的已经是另一张页，于是这个判断比较的其实是两个毫不相干的计数器。二者都是量级接近的小整数，迟早会撞上——这个 pane 就漏掉了它本该做的重传，然后拿着"合并后新布局"的坐标去采样一张还停留在"合并前旧内容"的纹理。凡是原本住在这一页上的字符，采样到的都是错误区域的错误图像。

恰好在 merge 那一刻正在渲染的 pane 会重新上传，没事；闲置的 pane 就此错乱，且不会自愈。

resize 能治好，是因为 `handleResize()` → `_refreshCharAtlas()` → `setAtlas()` 会把每个已记录的版本号强制设成 `-1`，逼出一次全量重传——这就是"拖一下分割条就好了"的原因。

这个问题上游没修：`@xterm/addon-webgl@0.19.0` / `@xterm/xterm@6.0.0` 依然保留着按下标比对版本号的逻辑，以及共享的 `CharAtlasCache`。

## 怎么修的

新增 `apps/web/src/terminal/glyphAtlas.ts`，订阅 atlas 的页面合并事件，收到后主动修复所有 pane。

- **触发信号**：`WebglAddon.onRemoveTextureAtlasCanvas` 只在 `_mergePages()` 里被触发，是字形坐标失效的精确信号——单纯新增一页不会触发它。（这个事件运行时确实存在，但 0.18 的 `.d.ts` 没有导出，所以改成从实例上直接读取；如果未来某个版本不再发出这个事件，也只是安静跳过，而不是让整个 pane 失去 GPU 渲染器。）
- **修复手段**：调用 `term.clearTextureAtlas()`——这是 xterm 官方文档给"纹理损坏"场景准备的方法：清空 atlas、把每一页的版本号都往前推、强制全量重绘。
- **必须修复所有 pane，而不只是发现问题的那一个**：atlas 是共享的，从某个 terminal 清空它，会让其余所有 terminal 手上的坐标一起失效——只修一个反而会把它的邻居弄花。
- **合并请求**：一次 merge 会触发一次事件 × 4 张被合并的页 × 每个转发这个事件的 pane，所以 8 个 pane 的场景下，一次 merge 大概会打进来 32 次请求，需要合并成一次修复。
- **延后执行**：merge 发生在别的 pane 渲染过程的中途，所以修复被安排到之后的一个任务里执行。
- **限流到 2 秒一次，超限的请求延后而不是丢弃**：一次修复会丢弃所有已光栅化的字形，而 merge 往往在 atlas 撑满时成串发生。如果丢弃而不是延后，会让那个 pane 一直错到下一次 merge 才有机会被修好。

## 验收

`apps/web/src/terminal/glyphAtlas.test.ts` —— 9 个单测，覆盖：合并请求去重、覆盖所有 pane、限流"延后不丢弃"、修复期间新挂载的 pane、修复过程中被销毁的 pane、以及事件缺失类型声明时的读取方式。全量测试：**91 个全部通过**，`tsc --noEmit` 和 `vite build` 均无问题。

除了单测之外，这个 bug 本身在 headless Chromium 里用真实的 `@xterm/xterm` + `@xterm/addon-webgl`、真实 WebGL context 端到端复现过（3 个 pane，用的是 Termany 的 `Terminal` options）。给每张 atlas page 的 canvas 打了 id，并记录每一次纹理上传实际传的是哪一页，所以失败条件是精确判定出来的，不是靠像素 diff 碰运气：

```
panes: 3; all share one atlas: true
phase 1: 80000 glyphs -> 30 pages, merges seen: 4/4/4
baseline: stale units per pane = 0/0/0
phase 2: 208 redraws, 88320 glyphs total, 30 pages, merges: 8/8/8
CORRUPTED: pane redrew fully, yet texture unit(s) 28 still hold a different atlas page
characters living on stale page 28: e.g. U+f2
stale units still present while it is on screen: 28
after clearTextureAtlas() on every pane: stale units per pane = 0/0/0
same characters render differently before vs after the repair: true
```

依次验证了：这些 pane 确实共享同一份 atlas；merge 信号确实传到了**每一个** pane（包括闲置的）；一个已经完整重绘过的 pane 依然可能绑定着错误的页；把这一页上的字符显示到屏幕上，`U+00F2`（`ò`）会渲染成完全不同的字形、完全不同的颜色——形状和颜色都错，因为前景色是被烤进 atlas 光栅里的。修复之后，所有 pane 都恢复正常。

