### PR TITLE
fix: 双击顶部标题栏无法最大化窗口（macOS 上 dblclick 之前不触发）

### DIFF
--- a/apps/web/src/components/HTabBar.tsx
+++ b/apps/web/src/components/HTabBar.tsx
@@ -1,4 +1,3 @@
-import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { beginDragCursor, createDragGhost, endDragCursor, type DragGhost } from "../dragGhost";
 import { isTauri } from "../env";
@@ -6,6 +5,7 @@ import { useI18n } from "../i18n";
 import { useImeGuard } from "../imeGuard";
 import { withShortcut } from "../keybindings";
 import { useStore, activeNode, type Pane } from "../state/store";
+import { titleBarBackground, useTitleBarGesture } from "../titleBar";
 import {
   acknowledgeAgentActivities,
   agentActivitySummary,
@@ -48,6 +48,7 @@ export function HTabBar() {
   const [editing, setEditing] = useState<string | null>(null);
   const suppressClickRef = useRef(false);
   const stripRef = useRef<HTMLDivElement>(null);
+  const titleBar = useTitleBarGesture();
 
   // Keep the active tab on screen — a tab created past the right edge would
   // otherwise be active but invisible. `nearest` no-ops when it already is.
@@ -84,15 +85,6 @@ export function HTabBar() {
       </button>
     </div>
   );
-
-  // The empty parts of the strip drag the window (desktop). Tabs/buttons are
-  // interactive, so clicks land on them, not the drag region. Double-clicking
-  // that same empty area zooms the window, macOS title-bar style — guarded to
-  // the bar itself so it doesn't fire from a bubbled tab/button dblclick.
-  const onBarDoubleClick = (e: React.MouseEvent) => {
-    if (!isTauri || e.target !== e.currentTarget) return;
-    void getCurrentWindow().toggleMaximize();
-  };
 
   const startTabDrag = (tabId: string, e: React.PointerEvent<HTMLDivElement>) => {
     if (!node || e.button !== 0 || editing === tabId) return;
@@ -169,13 +161,17 @@ export function HTabBar() {
     window.addEventListener("pointercancel", onUp);
   };
 
+  // The bar doubles as the window's title bar: its empty parts drag the window
+  // and zoom it on a double-click. Both background elements are marked, so the
+  // gesture covers the whole bar minus the tabs and buttons — the strip is
+  // flex: 1, and it alone accounts for nearly all of that empty space.
   return (
-    <div className={cls} data-tauri-drag-region onDoubleClick={onBarDoubleClick}>
+    <div className={cls} {...titleBar} {...titleBarBackground}>
       {controls}
       {/* Only the tabs scroll; the workspace controls and the panel toggle stay
           pinned to either end. Without this the strip just overflowed and a
           newly created tab sat off-screen, active but invisible. */}
-      <div className="htab-strip" ref={stripRef} data-tauri-drag-region>
+      <div className="htab-strip" ref={stripRef} {...titleBarBackground}>
       {node?.htabs.map((h) => (
         (() => {
           const ids = leafIds(h.layout);

--- a/apps/web/src/components/WorkspaceSwitcher.tsx
+++ b/apps/web/src/components/WorkspaceSwitcher.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useI18n } from "../i18n";
 import { useStore } from "../state/store";
+import { titleBarBackground, useTitleBarGesture } from "../titleBar";
 import { EmojiPicker } from "./EmojiPicker";
 import { ChevronIcon, EditIcon, GearIcon, PlusIcon, TrashIcon } from "./icons";
 import { WorkspaceDialog } from "./WorkspaceDialog";
@@ -32,6 +33,10 @@ export function WorkspaceSwitcher({ onOpenSettings }: { onOpenSettings: () => vo
   const [deleteTarget, setDeleteTarget] = useState<{ id: string; title: string } | null>(null);
 
   const active = workspaces.find((w) => w.id === activeId) ?? workspaces[0];
+  // Doubles as the window's title bar on desktop, same as the tab strip: the
+  // header's own background — the room reserved for the traffic lights, the
+  // gap, the right padding — drags the window and zooms it on a double-click.
+  const titleBar = useTitleBarGesture();
 
   const avatar = (w: { icon?: string; title: string }, sm = false) =>
     w.icon ? (
@@ -42,7 +47,7 @@ export function WorkspaceSwitcher({ onOpenSettings }: { onOpenSettings: () => vo
 
   return (
     <div className="ws-switcher">
-      <div className="ws-head" data-tauri-drag-region>
+      <div className="ws-head" {...titleBar} {...titleBarBackground}>
         <button className="ws-icon-btn" title={t("workspace.changeIcon")} onClick={() => setEmojiOpen((o) => !o)}>
           {avatar(active)}
         </button>

--- a/apps/web/src/titleBar.test.ts
+++ b/apps/web/src/titleBar.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createTitleBarGesture, type TitleBarMouse } from "./titleBar";
+
+const at = (x: number, y: number, over: Partial<TitleBarMouse> = {}): TitleBarMouse => ({
+  button: 0,
+  detail: 1,
+  screenX: x,
+  screenY: y,
+  background: true,
+  ...over,
+});
+
+test("drags the window from a single press on the bar background", () => {
+  const mac = createTitleBarGesture(true);
+  assert.equal(mac.down(at(100, 10)), "drag");
+  const win = createTitleBarGesture(false);
+  assert.equal(win.down(at(100, 10)), "drag");
+});
+
+test("macOS zooms on the release of the second click, not its press", () => {
+  const g = createTitleBarGesture(true);
+  g.down(at(100, 10));
+  assert.equal(g.up(at(100, 10)), null);
+  // The second press must not start a drag — the native session would swallow
+  // the release we zoom on.
+  assert.equal(g.down(at(100, 10, { detail: 2 })), null);
+  assert.equal(g.up(at(100, 10, { detail: 2 })), "zoom");
+});
+
+test("macOS cancels the zoom when the pointer moves off the press", () => {
+  const g = createTitleBarGesture(true);
+  g.down(at(100, 10, { detail: 2 }));
+  assert.equal(g.up(at(140, 10, { detail: 2 })), null);
+});
+
+test("macOS tolerates the pixel of jitter a trackpad double-tap produces", () => {
+  const g = createTitleBarGesture(true);
+  g.down(at(100, 10, { detail: 2 }));
+  assert.equal(g.up(at(101, 11, { detail: 2 })), "zoom");
+});
+
+test("Windows and Linux zoom on the press, as those title bars do", () => {
+  const g = createTitleBarGesture(false);
+  assert.equal(g.down(at(100, 10, { detail: 2 })), "zoom");
+  assert.equal(g.up(at(100, 10, { detail: 2 })), null);
+});
+
+test("ignores presses that land on a tab or button", () => {
+  const g = createTitleBarGesture(true);
+  assert.equal(g.down(at(100, 10, { background: false })), null);
+  assert.equal(g.down(at(100, 10, { detail: 2, background: false })), null);
+  assert.equal(g.up(at(100, 10, { detail: 2, background: false })), null);
+});
+
+test("ignores non-primary buttons", () => {
+  const g = createTitleBarGesture(true);
+  assert.equal(g.down(at(100, 10, { button: 2 })), null);
+  assert.equal(g.down(at(100, 10, { button: 2, detail: 2 })), null);
+});
+
+test("does not zoom on a release the app never armed", () => {
+  const g = createTitleBarGesture(true);
+  assert.equal(g.up(at(100, 10, { detail: 2 })), null);
+});
+
+test("does not zoom when the release lands off the bar background", () => {
+  const g = createTitleBarGesture(true);
+  g.down(at(100, 10, { detail: 2 }));
+  assert.equal(g.up(at(100, 10, { detail: 2, background: false })), null);
+});
+
+test("the third press of a burst still drags, the zoom having already fired", () => {
+  const g = createTitleBarGesture(true);
+  g.down(at(100, 10, { detail: 2 }));
+  assert.equal(g.up(at(100, 10, { detail: 2 })), "zoom");
+  assert.equal(g.down(at(100, 10, { detail: 3 })), "drag");
+});
+
+test("a fresh press after a zoom drags again", () => {
+  const g = createTitleBarGesture(true);
+  g.down(at(100, 10, { detail: 2 }));
+  g.up(at(100, 10, { detail: 2 }));
+  assert.equal(g.down(at(200, 10)), "drag");
+  assert.equal(g.up(at(200, 10)), null);
+});

--- a/apps/web/src/titleBar.ts
+++ b/apps/web/src/titleBar.ts
@@ -1,0 +1,135 @@
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { useMemo, type MouseEvent } from "react";
+import { isTauri } from "./env";
+
+/**
+ * Native title-bar behaviour for the app's own chrome: drag the window from the
+ * empty parts of the top bar, double-click them to zoom.
+ *
+ * The desktop window is borderless (decorations: false), so neither gesture
+ * comes for free — and the obvious way to get them, tagging the bar with
+ * `data-tauri-drag-region`, does not work here. Tauri's injected handler treats
+ * a bare attribute as "direct clicks on this element only", and it insists the
+ * two coordinates of the zoom gesture match to the pixel. Owning the gesture in
+ * the app instead lets it span the bar's several background elements, and lets
+ * the tolerance be a human one. It also keeps a single owner: with the
+ * attribute still in place, a zero-jitter double-click could satisfy Tauri and
+ * the app both, maximizing and immediately restoring.
+ *
+ * The zoom rides on mousedown/mouseup and their click counts rather than the
+ * obvious `dblclick`, which never arrives on macOS: dragging goes through
+ * `performWindowDragWithEvent:`, whose own event loop consumes the release of
+ * the first click, so that click never completes and no double-click is ever
+ * synthesized from it.
+ *
+ * Elements that carry `data-titlebar` are the bar's background. A click landing
+ * on any other element is on a tab, a button, or a label, so it belongs to that
+ * control — dragging a tab must not drag the window out from under it.
+ */
+const TITLE_BAR_ATTR = "data-titlebar";
+
+/** Marks an element as bar background. Spread onto the elements themselves. */
+export const titleBarBackground = { [TITLE_BAR_ATTR]: "" } as const;
+
+/** What a press or release on the bar should do to the window. */
+export type TitleBarAction = "drag" | "zoom" | null;
+
+/** The parts of a mouse event the gesture reads, so it can be tested plainly. */
+export type TitleBarMouse = {
+  button: number;
+  /** Click count: 1 for the first press of a gesture, 2 for the second. */
+  detail: number;
+  screenX: number;
+  screenY: number;
+  /** Whether the event landed on the bar background rather than a control. */
+  background: boolean;
+};
+
+/**
+ * How far the pointer may drift between the second press and its release and
+ * still count as a double-click. macOS cancels the zoom if the pointer moves,
+ * which is the behaviour to match; the few pixels of slack are for trackpads,
+ * where a two-finger-free double tap rarely lands twice on the same pixel.
+ */
+const ZOOM_JITTER_PX = 4;
+
+/**
+ * Tracks one press/release pair. Platforms disagree on when a double-click
+ * zooms: Windows and Linux do it on the second press, macOS on its release, so
+ * that sliding off cancels. macOS therefore must not start a drag on that
+ * second press either — the native drag session runs its own event loop and
+ * would eat the release the zoom hangs on.
+ */
+export function createTitleBarGesture(isMac: boolean) {
+  let armed: { x: number; y: number } | null = null;
+
+  return {
+    down(e: TitleBarMouse): TitleBarAction {
+      armed = null;
+      if (e.button !== 0 || !e.background) return null;
+      if (e.detail === 2) {
+        if (!isMac) return "zoom";
+        armed = { x: e.screenX, y: e.screenY };
+        return null;
+      }
+      // Every other press drags, including the third of a rapid burst: the
+      // zoom already happened on the second, and a title bar stays draggable.
+      return e.detail >= 1 ? "drag" : null;
+    },
+
+    up(e: TitleBarMouse): TitleBarAction {
+      const start = armed;
+      armed = null;
+      if (!start || e.button !== 0 || e.detail !== 2 || !e.background) return null;
+      // Screen coordinates, not client: had the first click of the gesture
+      // nudged the window, client coordinates would report a move the hand
+      // never made.
+      const moved = Math.hypot(e.screenX - start.x, e.screenY - start.y);
+      return moved <= ZOOM_JITTER_PX ? "zoom" : null;
+    },
+  };
+}
+
+const IS_MAC = typeof navigator !== "undefined" && navigator.userAgent.includes("Mac");
+
+function read(event: MouseEvent): TitleBarMouse {
+  const target = event.target;
+  return {
+    button: event.button,
+    detail: event.detail,
+    screenX: event.screenX,
+    screenY: event.screenY,
+    background: target instanceof Element && target.hasAttribute(TITLE_BAR_ATTR),
+  };
+}
+
+/**
+ * Mouse handlers to spread onto a bar that should behave like a title bar. The
+ * bar's background elements need {...titleBarBackground} on them as well.
+ *
+ *   const titleBar = useTitleBarGesture();
+ *   <div className="htabbar" {...titleBar} {...titleBarBackground}>
+ */
+export function useTitleBarGesture() {
+  const gesture = useMemo(() => createTitleBarGesture(IS_MAC), []);
+
+  const apply = (action: TitleBarAction) => {
+    if (action === "drag") void getCurrentWindow().startDragging();
+    else if (action === "zoom") void getCurrentWindow().toggleMaximize();
+  };
+
+  return {
+    onMouseDown: (event: MouseEvent) => {
+      if (!isTauri) return;
+      const action = gesture.down(read(event));
+      if (!action) return;
+      // Without this the press leaves a text caret on the bar.
+      event.preventDefault();
+      apply(action);
+    },
+    onMouseUp: (event: MouseEvent) => {
+      if (!isTauri) return;
+      apply(gesture.up(read(event)));
+    },
+  };
+}


### PR DESCRIPTION
## 问题

顶部标签栏和侧栏 workspace 头部是无边框窗口的自绘标题栏，按 macOS 惯例双击应该缩放（zoom）窗口，但双击没有任何反应。只能靠拖动边缘改变窗口大小，很麻烦。

## 原因

这个功能其实在 v0.1.13（#49ad671 "dblclick zoom"）就写过，从上线起两条路径都是失效的：

**1. React 的 `onDoubleClick` 是死代码。** 拖动窗口走 tao 的 `drag_window()`，最终调用 AppKit 的 `[NSWindow performWindowDragWithEvent:]`。这个方法会跑自己的模态事件循环直到 mouse-up，**第一次点击的 mouseup 被它吞掉、不会送达 WKWebView**。于是第一次 `click` 永不完成，WebKit 也就永远不会合成 `dblclick`。

同一个 handler 上还叠了一个 `e.target !== e.currentTarget` 守卫，只认最外层 `.htabbar` 本身；而内层 `.htab-strip` 是 `flex: 1`，把整条 36px 顶栏的空白区几乎全部铺满，双击命中的都是 strip，即使 `dblclick` 能触发也会被这个守卫挡掉。

**2. Tauri 原生的 drag region 也顶不上。** 注入的 `drag.js` 里，**裸的 `data-tauri-drag-region` 只匹配直接命中该元素本身**（`el === composedPath[0]`），要覆盖子树得写成 `="deep"`；而且它在 macOS 上要求双击两次事件的 `clientX/clientY` **逐像素完全相等**，触控板轻点极易失败。

## 解决

前端完全接管这个手势，新增 `apps/web/src/titleBar.ts`：

- **不用 `dblclick`**，改由 `mousedown` / `mouseup` 上的 click count（`event.detail`）驱动。`detail` 源自 NSEvent 的 `clickCount`，由 AppKit 在系统层维护，不受 webview 有没有收到 mouseup 影响。
- **按平台分支**：macOS 在第二次 **mouseup** 缩放，保留「按下后滑开 = 取消」的原生语义，因此那次按下绝不能启动拖动（否则原生拖动会话又会吃掉缩放所依赖的 mouseup）；Windows / Linux 在第二次 **mousedown** 缩放。
- **位移判定用 screenX/Y 而非 clientX/Y**：第一次点击若把窗口挪了一点，client 坐标会汇报一个手其实没做的位移。给了 4px 容差，替代 Tauri 那个逐像素相等的判定。
- **删掉所有 `data-tauri-drag-region`**，保证单一所有者。两层并存时，一次零抖动的双击可能同时满足 Tauri 和本应用，最大化后立刻还原。
- 带 `data-titlebar` 的元素才算「栏的背景」，落在 tab、按钮、输入框上的点击一律排除——拖 tab 不能把窗口一起拖走。

侧栏的 `.ws-head` 一并接上，保持「能拖动窗口的地方就能双击缩放」的一致性。

## 测试

手势状态机抽成纯函数，新增 11 个单测覆盖：单击拖动、macOS 在 release 缩放、滑开取消、触控板抖动容差、Windows/Linux 在 press 缩放、落在 tab/按钮上不触发、非主键忽略、未 arm 的 release 不缩放、连击第三次仍可拖动。

`npm test` 123 项全绿，`tsc --noEmit` 干净，生产构建通过，桌面 app 实跑无运行时错误。

真实的双击手势已在桌面 app 上人工验证。
