### PR TITLE
feat: add seven new terminal color themes

### DIFF
--- a/apps/web/src/themes/aurora.ts
+++ b/apps/web/src/themes/aurora.ts
@@ -1,0 +1,50 @@
+import type { Theme } from "./types";
+
+// Original Termany theme. Aurora colors, flat surfaces: near-black navy
+// panes floating as cards over a violet-tinged chrome, electric teal accent,
+// neon ANSI. All solid color — the boldness is in the blocking, not art.
+export const aurora: Theme = {
+  id: "aurora",
+  name: "Aurora",
+  appearance: "dark",
+  colors: {
+    bg: "#0d1022",
+    bg2: "#171b3a",
+    bg3: "#232952",
+    border: "#2c3263",
+    fg: "#dbe2ff",
+    fgDim: "#7d86b8",
+    accent: "#37e6c3",
+    accentSoft: "rgba(55, 230, 195, 0.16)",
+  },
+  radius: { sm: "8px", md: "12px", lg: "16px" },
+  sidebar: { bg: "#12102b" },
+  chrome: {
+    paneGap: "10px",
+    paneRadius: "16px",
+    paneBorder: "rgba(150, 170, 255, 0.22)",
+    paneShadow: "0 6px 20px rgba(4, 8, 30, 0.5)",
+  },
+  term: {
+    background: "#0d1022",
+    foreground: "#dbe2ff",
+    cursor: "#37e6c3",
+    selectionBackground: "#2c3263",
+    black: "#232952",
+    red: "#ff6b8f",
+    green: "#3ddc97",
+    yellow: "#ffd166",
+    blue: "#5aa2ff",
+    magenta: "#b78cff",
+    cyan: "#45e3dd",
+    white: "#aeb6dd",
+    brightBlack: "#3a4373",
+    brightRed: "#ff8fab",
+    brightGreen: "#6ff0b4",
+    brightYellow: "#ffe08a",
+    brightBlue: "#82bbff",
+    brightMagenta: "#cfaaff",
+    brightCyan: "#74f0ea",
+    brightWhite: "#eef1ff",
+  },
+};

--- a/apps/web/src/themes/gruvbox-light.ts
+++ b/apps/web/src/themes/gruvbox-light.ts
@@ -1,0 +1,47 @@
+import type { Theme } from "./types";
+
+// Ported from Gruvbox Light (https://github.com/morhetz/gruvbox, MIT/X11;
+// ANSI palette via https://github.com/mbadolato/iTerm2-Color-Schemes, MIT).
+//
+// The cream side of the same retro palette: bg0 → terminal panes, bg1 →
+// chrome, bg2 → hover/borders, burnt orange as accent. One departure: the
+// upstream scheme's near-black selection would bury un-inverted xterm text,
+// so selection uses bg2 like gruvbox terminals typically do.
+export const gruvboxLight: Theme = {
+  id: "gruvbox-light",
+  name: "Gruvbox Light",
+  appearance: "light",
+  colors: {
+    bg: "#fbf1c7",
+    bg2: "#ebdbb2",
+    bg3: "#d5c4a1",
+    border: "#d5c4a1",
+    fg: "#3c3836",
+    fgDim: "#7c6f64",
+    accent: "#d65d0e",
+    accentSoft: "rgba(214, 93, 14, 0.12)",
+  },
+  radius: { sm: "4px", md: "6px", lg: "8px" },
+  term: {
+    background: "#fbf1c7",
+    foreground: "#3c3836",
+    cursor: "#3c3836",
+    selectionBackground: "#d5c4a1",
+    black: "#fbf1c7",
+    red: "#cc241d",
+    green: "#98971a",
+    yellow: "#d79921",
+    blue: "#458588",
+    magenta: "#b16286",
+    cyan: "#689d6a",
+    white: "#7c6f64",
+    brightBlack: "#928374",
+    brightRed: "#9d0006",
+    brightGreen: "#79740e",
+    brightYellow: "#b57614",
+    brightBlue: "#076678",
+    brightMagenta: "#8f3f71",
+    brightCyan: "#427b58",
+    brightWhite: "#3c3836",
+  },
+};

--- a/apps/web/src/themes/gruvbox.ts
+++ b/apps/web/src/themes/gruvbox.ts
@@ -1,0 +1,47 @@
+import type { Theme } from "./types";
+
+// Ported from Gruvbox (https://github.com/morhetz/gruvbox, MIT/X11; ANSI
+// palette via https://github.com/mbadolato/iTerm2-Color-Schemes, MIT).
+//
+// Warm retro browns off the medium-contrast palette: bg0 → terminal panes,
+// bg0_soft → chrome, bg0_hard → a recessed sidebar rail, and the signature
+// bright orange as accent. Small radii on purpose — boxy suits gruvbox.
+export const gruvbox: Theme = {
+  id: "gruvbox",
+  name: "Gruvbox Dark",
+  appearance: "dark",
+  colors: {
+    bg: "#282828",
+    bg2: "#32302f",
+    bg3: "#504945",
+    border: "#504945",
+    fg: "#ebdbb2",
+    fgDim: "#928374",
+    accent: "#fe8019",
+    accentSoft: "rgba(254, 128, 25, 0.15)",
+  },
+  radius: { sm: "4px", md: "6px", lg: "8px" },
+  sidebar: { bg: "#1d2021" },
+  term: {
+    background: "#282828",
+    foreground: "#ebdbb2",
+    cursor: "#ebdbb2",
+    selectionBackground: "#665c54",
+    black: "#282828",
+    red: "#cc241d",
+    green: "#98971a",
+    yellow: "#d79921",
+    blue: "#458588",
+    magenta: "#b16286",
+    cyan: "#689d6a",
+    white: "#a89984",
+    brightBlack: "#928374",
+    brightRed: "#fb4934",
+    brightGreen: "#b8bb26",
+    brightYellow: "#fabd2f",
+    brightBlue: "#83a598",
+    brightMagenta: "#d3869b",
+    brightCyan: "#8ec07c",
+    brightWhite: "#ebdbb2",
+  },
+};

--- a/apps/web/src/themes/horizon.ts
+++ b/apps/web/src/themes/horizon.ts
@@ -1,0 +1,50 @@
+import type { Theme } from "./types";
+
+// Original Termany theme. Sunset warmth in flat blocks: cream cards floating
+// over solid peach chrome with a deeper peach sidebar, coral accent. No
+// gradients — the warm color blocking carries it.
+export const horizon: Theme = {
+  id: "horizon",
+  name: "Horizon",
+  appearance: "light",
+  colors: {
+    bg: "#fffaf4",
+    bg2: "#ffe9d9",
+    bg3: "#ffd9c2",
+    border: "#f0cfb8",
+    fg: "#46425e",
+    fgDim: "#8d8699",
+    accent: "#f96f5d",
+    accentSoft: "rgba(249, 111, 93, 0.14)",
+  },
+  radius: { sm: "10px", md: "12px", lg: "16px" },
+  sidebar: { bg: "#ffdfc9" },
+  chrome: {
+    paneGap: "10px",
+    paneRadius: "16px",
+    paneBorder: "rgba(70, 64, 92, 0.12)",
+    paneShadow: "0 6px 18px rgba(150, 90, 70, 0.2)",
+  },
+  term: {
+    background: "#fffaf4",
+    foreground: "#46425e",
+    cursor: "#f96f5d",
+    selectionBackground: "rgba(249, 111, 93, 0.22)",
+    black: "#ece4da",
+    red: "#d6455d",
+    green: "#2f9e6e",
+    yellow: "#c07f00",
+    blue: "#3a74d9",
+    magenta: "#a75ac8",
+    cyan: "#0f9ba8",
+    white: "#6f6a85",
+    brightBlack: "#a49d92",
+    brightRed: "#e4576f",
+    brightGreen: "#37b980",
+    brightYellow: "#d9950a",
+    brightBlue: "#5b8ce4",
+    brightMagenta: "#bc74da",
+    brightCyan: "#16b4c2",
+    brightWhite: "#46425e",
+  },
+};

--- a/apps/web/src/themes/index.ts
+++ b/apps/web/src/themes/index.ts
@@ -1,9 +1,16 @@
 import { applyTermTheme } from "../terminal/manager";
+import { aurora } from "./aurora";
 import { charcoal } from "./charcoal";
 import { codex } from "./codex";
 import { daylight } from "./daylight";
 import { defaultDark } from "./default-dark";
+import { gruvbox } from "./gruvbox";
+import { gruvboxLight } from "./gruvbox-light";
+import { horizon } from "./horizon";
 import { meadow } from "./meadow";
+import { phosphor } from "./phosphor";
+import { rosePine } from "./rose-pine";
+import { rosePineDawn } from "./rose-pine-dawn";
 import { solarizedDark } from "./solarized-dark";
 import type { Theme } from "./types";
 
@@ -21,6 +28,13 @@ export const THEMES: Theme[] = [
   daylight,
   meadow,
   charcoal,
+  gruvbox,
+  gruvboxLight,
+  rosePine,
+  rosePineDawn,
+  aurora,
+  horizon,
+  phosphor,
   codex,
 ];
 

--- a/apps/web/src/themes/phosphor.ts
+++ b/apps/web/src/themes/phosphor.ts
@@ -1,0 +1,50 @@
+import type { Theme } from "./types";
+
+// Original Termany theme. A green-phosphor CRT: near-black glass, everything
+// in the green ramp, hard corners, flush edge-to-edge panes — the anti-card.
+// ANSI keeps usable semantic hues (red errors, chartreuse yellow, violet
+// magenta) but pulls every one toward the phosphor glow.
+export const phosphor: Theme = {
+  id: "phosphor",
+  name: "Phosphor",
+  appearance: "dark",
+  colors: {
+    bg: "#010402",
+    bg2: "#04120a",
+    bg3: "#0a2416",
+    border: "#0f3520",
+    fg: "#3dff8c",
+    fgDim: "#1e9e5a",
+    accent: "#3dff8c",
+    accentSoft: "rgba(61, 255, 140, 0.18)",
+  },
+  radius: { sm: "2px", md: "3px", lg: "4px" },
+  chrome: {
+    paneGap: "0px",
+    paneRadius: "0px",
+    paneBorder: "transparent",
+    paneShadow: "none",
+  },
+  term: {
+    background: "#010402",
+    foreground: "#3dff8c",
+    cursor: "#3dff8c",
+    selectionBackground: "#0f3520",
+    black: "#0a2416",
+    red: "#ff6d5a",
+    green: "#3dff8c",
+    yellow: "#d8ff5e",
+    blue: "#4aa8ff",
+    magenta: "#b591ff",
+    cyan: "#35e0c8",
+    white: "#b8ffd6",
+    brightBlack: "#14663c",
+    brightRed: "#ff8a75",
+    brightGreen: "#7dffb4",
+    brightYellow: "#eaff9c",
+    brightBlue: "#7cc0ff",
+    brightMagenta: "#cbb0ff",
+    brightCyan: "#78f0dd",
+    brightWhite: "#eafff2",
+  },
+};

--- a/apps/web/src/themes/rose-pine-dawn.ts
+++ b/apps/web/src/themes/rose-pine-dawn.ts
@@ -1,0 +1,47 @@
+import type { Theme } from "./types";
+
+// Ported from Rosé Pine Dawn (https://github.com/rose-pine/palette and
+// https://github.com/rose-pine/alacritty), MIT License.
+//
+// Dawn inverts the depth: surface is a near-white that floats ABOVE the
+// warm paper base, so the chrome is lighter than the terminal — same move
+// as codex. Roles otherwise mirror rose-pine: overlay → hover,
+// highlight-med → borders, rose → accent.
+export const rosePineDawn: Theme = {
+  id: "rose-pine-dawn",
+  name: "Rosé Pine Dawn",
+  appearance: "light",
+  colors: {
+    bg: "#faf4ed",
+    bg2: "#fffaf3",
+    bg3: "#f2e9e1",
+    border: "#dfdad9",
+    fg: "#575279",
+    fgDim: "#797593",
+    accent: "#d7827e",
+    accentSoft: "rgba(215, 130, 126, 0.12)",
+  },
+  radius: { sm: "8px", md: "10px", lg: "14px" },
+  term: {
+    background: "#faf4ed",
+    foreground: "#575279",
+    cursor: "#cecacd",
+    selectionBackground: "#dfdad9",
+    black: "#f2e9e1",
+    red: "#b4637a",
+    green: "#286983",
+    yellow: "#ea9d34",
+    blue: "#56949f",
+    magenta: "#907aa9",
+    cyan: "#d7827e",
+    white: "#575279",
+    brightBlack: "#9893a5",
+    brightRed: "#b4637a",
+    brightGreen: "#286983",
+    brightYellow: "#ea9d34",
+    brightBlue: "#56949f",
+    brightMagenta: "#907aa9",
+    brightCyan: "#d7827e",
+    brightWhite: "#575279",
+  },
+};

--- a/apps/web/src/themes/rose-pine.ts
+++ b/apps/web/src/themes/rose-pine.ts
@@ -1,0 +1,46 @@
+import type { Theme } from "./types";
+
+// Ported from Rosé Pine (https://github.com/rose-pine/palette and
+// https://github.com/rose-pine/alacritty), MIT License.
+//
+// The official role mapping: base → terminal panes, surface → chrome,
+// overlay → hover, highlight-med → borders (per the palette spec), subtle →
+// muted text, rose → accent. Generous radii — soho vibes, not a toolbox.
+export const rosePine: Theme = {
+  id: "rose-pine",
+  name: "Rosé Pine",
+  appearance: "dark",
+  colors: {
+    bg: "#191724",
+    bg2: "#1f1d2e",
+    bg3: "#26233a",
+    border: "#403d52",
+    fg: "#e0def4",
+    fgDim: "#908caa",
+    accent: "#ebbcba",
+    accentSoft: "rgba(235, 188, 186, 0.14)",
+  },
+  radius: { sm: "8px", md: "10px", lg: "14px" },
+  term: {
+    background: "#191724",
+    foreground: "#e0def4",
+    cursor: "#524f67",
+    selectionBackground: "#403d52",
+    black: "#26233a",
+    red: "#eb6f92",
+    green: "#31748f",
+    yellow: "#f6c177",
+    blue: "#9ccfd8",
+    magenta: "#c4a7e7",
+    cyan: "#ebbcba",
+    white: "#e0def4",
+    brightBlack: "#6e6a86",
+    brightRed: "#eb6f92",
+    brightGreen: "#31748f",
+    brightYellow: "#f6c177",
+    brightBlue: "#9ccfd8",
+    brightMagenta: "#c4a7e7",
+    brightCyan: "#ebbcba",
+    brightWhite: "#e0def4",
+  },
+};


### PR DESCRIPTION
## Summary

Adds seven new built-in terminal color themes:

- **Gruvbox** / **Gruvbox Light**
- **Rosé Pine** / **Rosé Pine Dawn**
- **Aurora**
- **Horizon**
- **Phosphor**

All themes are registered in `apps/web/src/themes/index.ts` and follow the existing `Theme` type structure.

## Changes

- 7 new theme files under `apps/web/src/themes/`
- Theme registration in `index.ts`

## Screenshots

| Gruvbox Dark | Gruvbox Light |
|---|---|
| ![Gruvbox Dark](https://raw.githubusercontent.com/thinkany-ai/termany/37b045b8a9b7bf34fa1aaf5aa7665cc918f72a36/gruvbox-dark.jpg) | ![Gruvbox Light](https://raw.githubusercontent.com/thinkany-ai/termany/37b045b8a9b7bf34fa1aaf5aa7665cc918f72a36/gruvbox-light.jpg) |

| Rosé Pine | Rosé Pine Dawn |
|---|---|
| ![Rosé Pine](https://raw.githubusercontent.com/thinkany-ai/termany/37b045b8a9b7bf34fa1aaf5aa7665cc918f72a36/rose-pine.jpg) | ![Rosé Pine Dawn](https://raw.githubusercontent.com/thinkany-ai/termany/37b045b8a9b7bf34fa1aaf5aa7665cc918f72a36/rose-pine-dawn.jpg) |

| Aurora | Horizon |
|---|---|
| ![Aurora](https://raw.githubusercontent.com/thinkany-ai/termany/37b045b8a9b7bf34fa1aaf5aa7665cc918f72a36/aurora.jpg) | ![Horizon](https://raw.githubusercontent.com/thinkany-ai/termany/37b045b8a9b7bf34fa1aaf5aa7665cc918f72a36/horizon.jpg) |

| Phosphor | |
|---|---|
| ![Phosphor](https://raw.githubusercontent.com/thinkany-ai/termany/37b045b8a9b7bf34fa1aaf5aa7665cc918f72a36/phosphor.jpg) | |

(Screenshots hosted on the `assets/theme-previews` branch.)

## Testing

- `tsc --noEmit` passes
- Verified each theme in the running app (screenshots above)