### PR TITLE
fix: 关闭 pane 后高亮边框标错了 pane

### DIFF
--- a/apps/web/src/components/SplitView.tsx
+++ b/apps/web/src/components/SplitView.tsx
@@ -320,6 +320,10 @@ function PaneHeader({
           <button
             className="pane-btn"
             title={withShortcut("Close pane", "closePane")}
+            // Don't let the slot's mousedown focus a pane we're about to close:
+            // it would make closing ANY pane look like closing the focused one,
+            // and focus would leave the pane the user was actually working in.
+            onMouseDown={(e) => e.stopPropagation()}
             onClick={() => closePane(leaf.id)}
           >
             <CloseIcon />

--- a/apps/web/src/components/TerminalPane.tsx
+++ b/apps/web/src/components/TerminalPane.tsx
@@ -78,7 +78,18 @@ export function TerminalPane({ id, sshTarget }: { id: string; sshTarget?: string
   useEffect(() => {
     const host = hostRef.current;
     if (!host) return;
-    attachSession(sessionId, host, cwdCandidates(useStore.getState(), id), sshTarget, id);
+    // Read, don't subscribe: only whether THIS pane owns the keyboard at the
+    // moment it mounts. A pane that remounts because a sibling closed must not
+    // pull focus off the pane the store actually focused.
+    const state = useStore.getState();
+    attachSession(
+      sessionId,
+      host,
+      cwdCandidates(state, id),
+      sshTarget,
+      id,
+      activeHtab(state)?.focused === id
+    );
     const unsubscribeScrollState = subscribeTerminalScrollState(sessionId, setScrollState);
 
     // Coalesce resize bursts (window/split-drag fires RO every frame) to ONE fit

--- a/apps/web/src/state/paneFocus.ts
+++ b/apps/web/src/state/paneFocus.ts
@@ -1,0 +1,51 @@
+/**
+ * Which pane takes the focus ring when another one closes.
+ *
+ * Closing used to hand focus to the tab's very first leaf, which is almost
+ * never where the user was looking — close the bottom-right pane of a grid and
+ * the ring jumped to the top-left corner. The neighbour is the pane that
+ * visually GROWS into the freed space, so that is the one that gets focus.
+ *
+ * Kept free of runtime imports so it can be exercised directly.
+ */
+import type { Pane } from "./store";
+
+function firstLeaf(pane: Pane): string {
+  return pane.kind === "leaf" ? pane.id : firstLeaf(pane.children[0]);
+}
+
+function lastLeaf(pane: Pane): string {
+  return pane.kind === "leaf" ? pane.id : lastLeaf(pane.children[pane.children.length - 1]);
+}
+
+/**
+ * The leaf that should hold focus once `leafId` is removed from `layout`:
+ * its nearest sibling in the split that held it — the one after it, else the
+ * one before. Descending a sibling subtree enters it from the touching edge
+ * (the next one's first leaf, the previous one's last), so focus lands on the
+ * pane that was physically adjacent rather than that subtree's corner.
+ *
+ * `null` when there is no neighbour to pick: the closed pane was the whole
+ * layout, or it isn't in this layout at all. Callers keep their own fallback.
+ *
+ * Pass the layout as it was BEFORE the removal — the siblings are what makes
+ * the choice.
+ */
+export function nextFocusAfterClose(layout: Pane, leafId: string): string | null {
+  if (layout.kind === "leaf") return null;
+
+  const i = layout.children.findIndex((c) => c.kind === "leaf" && c.id === leafId);
+  if (i >= 0) {
+    const after = layout.children[i + 1];
+    if (after) return firstLeaf(after);
+    const before = layout.children[i - 1];
+    if (before) return lastLeaf(before);
+    return null; // a one-child split shouldn't exist, but don't invent a pane
+  }
+
+  for (const child of layout.children) {
+    const hit = nextFocusAfterClose(child, leafId);
+    if (hit) return hit;
+  }
+  return null;
+}

--- a/apps/web/src/state/store.ts
+++ b/apps/web/src/state/store.ts
@@ -15,6 +15,7 @@ import {
 } from "../rail-config";
 import { claimPage, readWindowPref, writeWindowPref } from "./windows";
 import { stepWorkspace } from "./layoutMerge";
+import { nextFocusAfterClose } from "./paneFocus";
 import { nextCyclablePaneView } from "./paneViewCycle";
 
 /**
@@ -877,6 +878,9 @@ function closeLeaf(s: State, leafId: string): Partial<State> {
   const { workspaceId, nodeId, htab } = home;
   disposePaneSessions(leafId);
   const layout = removeLeaf(htab.layout, leafId);
+  // Resolved against the layout as it stood, so the siblings are still there to
+  // pick from; `removeLeaf` only drops `leafId`, so the neighbour survives it.
+  const neighbor = nextFocusAfterClose(htab.layout, leafId);
   return {
     workspaces: inWs(s.workspaces, workspaceId, (ws) => ({
       ...ws,
@@ -897,7 +901,7 @@ function closeLeaf(s: State, leafId: string): Partial<State> {
             return {
               ...h,
               layout,
-              focused: h.focused === leafId ? firstLeaf(layout) : h.focused,
+              focused: h.focused === leafId ? (neighbor ?? firstLeaf(layout)) : h.focused,
               maximized: h.maximized === leafId ? undefined : h.maximized,
             };
           }),
@@ -1700,6 +1704,7 @@ export const useStore = create<State>((set, get) => ({
           const dragged = source ? findLeaf(source.layout, dragId) : undefined;
           if (!source || !target || !dragged) return n;
           const without = removeLeaf(source.layout, dragId);
+          const neighbor = nextFocusAfterClose(source.layout, dragId);
           return {
             ...n,
             activeHTab: targetHTabId,
@@ -1712,7 +1717,7 @@ export const useStore = create<State>((set, get) => ({
                 return {
                   ...h,
                   layout: without,
-                  focused: h.focused === dragId ? firstLeaf(without) : h.focused,
+                  focused: h.focused === dragId ? (neighbor ?? firstLeaf(without)) : h.focused,
                   maximized: h.maximized === dragId ? undefined : h.maximized,
                 };
               }
@@ -1741,6 +1746,7 @@ export const useStore = create<State>((set, get) => ({
           if (!source || !dragged) return n;
           const without = removeLeaf(source.layout, dragId);
           if (!without) return n; // last pane of the tab — nothing to detach
+          const neighbor = nextFocusAfterClose(source.layout, dragId);
           const created: HTab = {
             id: id(),
             title: dragged.title,
@@ -1756,7 +1762,7 @@ export const useStore = create<State>((set, get) => ({
                   ? {
                       ...h,
                       layout: without,
-                      focused: h.focused === dragId ? firstLeaf(without) : h.focused,
+                      focused: h.focused === dragId ? (neighbor ?? firstLeaf(without)) : h.focused,
                       maximized: h.maximized === dragId ? undefined : h.maximized,
                     }
                   : h
@@ -1780,6 +1786,7 @@ export const useStore = create<State>((set, get) => ({
         if (!from || !source || !dragged || !findNode(ws.roots, toNodeId)) return ws;
         const without = removeLeaf(source.layout, dragId);
         if (!without) return ws; // last pane of the tab — nothing to detach
+        const neighbor = nextFocusAfterClose(source.layout, dragId);
         const created: HTab = {
           id: id(),
           title: dragged.title,
@@ -1793,7 +1800,7 @@ export const useStore = create<State>((set, get) => ({
               ? {
                   ...h,
                   layout: without,
-                  focused: h.focused === dragId ? firstLeaf(without) : h.focused,
+                  focused: h.focused === dragId ? (neighbor ?? firstLeaf(without)) : h.focused,
                   maximized: h.maximized === dragId ? undefined : h.maximized,
                 }
               : h

--- a/apps/web/src/terminal/manager.ts
+++ b/apps/web/src/terminal/manager.ts
@@ -1592,13 +1592,23 @@ function fixAbandonedImeFinalize(term: Terminal) {
   );
 }
 
-/** Attach the session's element into `host` and open the terminal (once). */
+/**
+ * Attach the session's element into `host` and open the terminal (once).
+ *
+ * `focus` must say whether this pane is the focused one. Removing a pane
+ * collapses its parent split, which changes the React key of every surviving
+ * pane in it and remounts them all; taking the keyboard unconditionally here
+ * handed it to whichever pane happened to mount LAST while the focus ring
+ * stayed on the pane the store had focused. Ring and keyboard then disagreed
+ * until the next click.
+ */
 export function attachSession(
   id: string,
   host: HTMLElement,
   cwdFrom?: string[],
   sshTarget?: string,
-  paneId = id
+  paneId = id,
+  focus = true
 ) {
   activeSessionByPane.set(paneId, id);
   let owned = sessionIdsByPane.get(paneId);
@@ -1646,7 +1656,7 @@ export function attachSession(
     s.opened = true;
   }
   fitSession(id);
-  focusSession(id);
+  if (focus) focusSession(id);
   const queued = pendingCommands.get(paneId) ?? pendingCommands.get(id);
   if (queued?.length) {
     pendingCommands.delete(paneId);

--- a/apps/web/tests/paneFocus.test.ts
+++ b/apps/web/tests/paneFocus.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { nextFocusAfterClose } from "../src/state/paneFocus";
+import type { Pane } from "../src/state/store";
+
+const leaf = (id: string): Pane => ({ kind: "leaf", id, title: id });
+const row = (...children: Pane[]): Pane => ({ kind: "split", dir: "row", children });
+const col = (...children: Pane[]): Pane => ({ kind: "split", dir: "col", children });
+
+describe("nextFocusAfterClose", () => {
+  it("hands focus to the pane after the closed one", () => {
+    assert.equal(nextFocusAfterClose(row(leaf("a"), leaf("b"), leaf("c")), "b"), "c");
+  });
+
+  it("falls back to the pane before it when the closed pane was last", () => {
+    assert.equal(nextFocusAfterClose(row(leaf("a"), leaf("b"), leaf("c")), "c"), "b");
+  });
+
+  it("stays inside the split that held the closed pane", () => {
+    // row[ a , col[b, c] ] — closing c must land on b, its own sibling, and
+    // not jump across the tab to a.
+    assert.equal(nextFocusAfterClose(row(leaf("a"), col(leaf("b"), leaf("c"))), "c"), "b");
+  });
+
+  it("picks the nearest edge of a neighbouring subtree, not its first leaf", () => {
+    // row[ col[a, b] , c ] — closing c grows the left column, whose visually
+    // nearest pane is b (its bottom), not a.
+    assert.equal(nextFocusAfterClose(row(col(leaf("a"), leaf("b")), leaf("c")), "c"), "b");
+  });
+
+  it("enters the next subtree at its first leaf", () => {
+    assert.equal(nextFocusAfterClose(row(leaf("a"), col(leaf("b"), leaf("c"))), "a"), "b");
+  });
+
+  it("never returns the pane being closed", () => {
+    const layout = row(leaf("a"), col(leaf("b"), leaf("c")), leaf("d"));
+    for (const id of ["a", "b", "c", "d"]) {
+      assert.notEqual(nextFocusAfterClose(layout, id), id);
+    }
+  });
+
+  it("returns null when the closed pane was the only one", () => {
+    assert.equal(nextFocusAfterClose(leaf("a"), "a"), null);
+  });
+
+  it("returns null for a pane that is not in the layout", () => {
+    assert.equal(nextFocusAfterClose(row(leaf("a"), leaf("b")), "zzz"), null);
+  });
+});


### PR DESCRIPTION
## 问题

关掉一个 pane 之后，高亮边框跑到了第一个 pane 上，而实际接收键盘输入的却是另一个 pane —— 边框和真实焦点分家了。

## 原因

两个独立的问题叠在一起：

1. **焦点跳到第一个 pane。** `closeLeaf` 写死了 `focused: firstLeaf(layout)`，也就是整个 tab 最左上角那个 pane，而不是被关 pane 的邻居。

2. **真实键盘焦点被 remount 抢走。** 关闭 pane 会让父 split 塌缩（`removeLeaf` 在只剩一个子节点时返回该子节点），于是 `leafKey` 拼出的 React key 变化，该 split 里幸存的 pane 全部重新挂载；而 `attachSession` 结尾无条件调用 `focusSession(id)`，谁最后挂载谁抢到键盘，边框却仍跟着 store 的 `focused`。

另外，关闭按钮的点击本身也会改焦点：`.pane-slot` 的 `onMouseDown` 早于按钮的 `onClick`，所以点任意 pane 的 X 都会先把焦点设到它身上，导致「关别的 pane」被当成「关当前焦点 pane」，把用户正在使用的那个 pane 的焦点弄丢。

## 解决办法

- 新增 `nextFocusAfterClose()`：取被关 pane 在**同一个 split 内的兄弟节点**，优先后一个、否则前一个；进入相邻子树时从贴边那侧进（后一个取首 leaf，前一个取末 leaf）。选中的正是「长进刚腾出来那块空间」的 pane，焦点落在视线已经在的地方，而不是跨到 tab 的另一个角落。
- 拖拽 pane 离开所属 tab 的三条路径（`movePaneToHTab` / `movePaneToNewHTab` / `movePaneToNode`）有同样的 `firstLeaf` 回退问题，一并修掉。
- `attachSession` 增加 `focus` 参数，由 `TerminalPane` 传入 —— 用的是和 `PaneSlot` 画边框**完全相同**的表达式（`activeHtab(state)?.focused === id`），因此挂载时边框与键盘不可能再分歧。
- 关闭按钮加 `onMouseDown` 阻止冒泡，关闭非焦点 pane 时焦点原地不动。

## 验证

- 新增 `apps/web/tests/paneFocus.test.ts`，8 个用例覆盖邻居选取规则（含嵌套 split、贴边进入、绝不返回被关 pane 本身）
- `npm test` 139/139 通过
- `tsc --noEmit` 与 `npm run build` 均通过
- 人工测试通过