### PR TITLE
fix: 卡住的 agent 被误判成绿点后再也变不回黄

### DIFF
--- a/apps/server/src/agentActivity.test.ts
+++ b/apps/server/src/agentActivity.test.ts
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { AgentActivityTracker } from "./agentActivity.js";
+
+/**
+ * The green dot is a latch: a completion stays until the user acknowledges
+ * it, because output must never be able to swallow an unread notification.
+ * A completion settled too early inverts that protection — the agent is
+ * still working and the latch keeps the lie — so live busy evidence for the
+ * exact same epoch is allowed to pull the task back to working. Nothing
+ * else is: a guessed or stale epoch must bounce off, and an acknowledged
+ * completion is gone for good.
+ */
+
+function tracker(): { tracker: AgentActivityTracker; changes: () => number } {
+  let count = 0;
+  const t = new AgentActivityTracker({
+    now: () => 1_000,
+    onChange: () => count++,
+  });
+  return { tracker: t, changes: () => count };
+}
+
+test("live busy evidence pulls a premature done back to working", () => {
+  const { tracker: t } = tracker();
+  t.register("s1", "claude");
+  t.reportIdle("s1", 1, true);
+  assert.equal(t.snapshot().s1.status, "done");
+
+  assert.equal(t.reportWorking("s1", 1), true);
+  const activity = t.snapshot().s1;
+  assert.equal(activity.status, "working");
+  assert.equal(activity.taskEpoch, 1, "resuming is the same task, not a new one");
+  assert.equal(activity.agent, "claude");
+});
+
+test("a resumed task can settle again under the same epoch", () => {
+  const { tracker: t } = tracker();
+  t.register("s1", "claude");
+  t.reportIdle("s1", 1, true);
+  t.reportWorking("s1", 1);
+  assert.equal(t.reportIdle("s1", 1, true), true);
+  assert.equal(t.snapshot().s1.status, "done");
+});
+
+test("a stale or guessed epoch cannot resurrect a task", () => {
+  const { tracker: t } = tracker();
+  t.register("s1", "claude");
+  t.reportIdle("s1", 1, true);
+  assert.equal(t.reportWorking("s1", 2), false);
+  assert.equal(t.reportWorking("s1", 0), false);
+  assert.equal(t.snapshot().s1.status, "done");
+  assert.equal(t.reportWorking("missing", 1), false);
+});
+
+test("a rendered screen cannot re-own a pty the shell took back", () => {
+  const { tracker: t } = tracker();
+  t.register("s1", "claude");
+  t.reportIdle("s1", 1, true);
+  // The foreground sampler saw the agent leave and the shell get the terminal
+  // back: whatever spinner row is still on screen, the agent process is gone.
+  t.noteForegroundJob("s1", "2.1.220", "/bin/zsh");
+  t.noteForegroundJob("s1", "zsh", "/bin/zsh");
+  assert.equal(t.reportWorking("s1", 1), false);
+  assert.equal(t.snapshot().s1.status, "done");
+});
+
+test("an acknowledged completion stays cleared", () => {
+  const { tracker: t } = tracker();
+  t.register("s1", "claude");
+  t.reportIdle("s1", 1, true);
+  t.acknowledge([{ id: "s1", taskEpoch: 1 }]);
+  assert.equal(t.reportWorking("s1", 1), false);
+  assert.equal(t.snapshot().s1, undefined);
+});
+
+test("a blocked question resumes to working when the agent moves on", () => {
+  // A keypress-only menu answer never reaches the input heuristics, so the
+  // busy screen that follows is the only proof the question was answered.
+  const { tracker: t } = tracker();
+  t.register("s1", "claude");
+  t.reportBlocked("s1", 1);
+  assert.equal(t.snapshot().s1.status, "error");
+  assert.equal(t.reportWorking("s1", 1), true);
+  assert.equal(t.snapshot().s1.status, "working");
+});
+
+test("confirming an already-working task changes nothing", () => {
+  const { tracker: t, changes } = tracker();
+  t.register("s1", "claude");
+  const before = changes();
+  assert.equal(t.reportWorking("s1", 1), true);
+  assert.equal(t.snapshot().s1.status, "working");
+  assert.equal(changes(), before, "no change event for a no-op confirmation");
+});

--- a/apps/server/src/agentActivity.ts
+++ b/apps/server/src/agentActivity.ts
@@ -300,6 +300,36 @@ export class AgentActivityTracker {
   }
 
   /**
+   * Pull a settled task back to working on live-screen evidence for its
+   * exact epoch.
+   *
+   * The green latch protects unread *true* completions from being swallowed
+   * by output. A completion settled too early inverts that protection: an
+   * agent that stalls past the client's quiet window reads as finished, and
+   * once latched, nothing the screen paints can say otherwise — the session
+   * stays green through half an hour of visible work. A spinner repainting
+   * under the same epoch is proof the task never ended, so it, and only it,
+   * may repaint the latch. An answered question resumes through here too:
+   * keypress-only menus never reach the input heuristics, so the busy screen
+   * that follows is the only evidence the question was dealt with.
+   *
+   * A rendered screen may repaint the latch, never re-own the pty: once the
+   * foreground sampler has seen the shell take the terminal back, the agent
+   * process is gone and no spinner row still on screen can bring it back.
+   */
+  reportWorking(id: string, taskEpoch: number): boolean {
+    const current = this.activities.get(id);
+    if (!current || current.taskEpoch !== taskEpoch) return false;
+    const stream = this.stream(id);
+    if (stream.taskEpoch !== taskEpoch) return false;
+    if (!stream.agentActive) return false;
+    stream.awaitingRegisteredInput = false;
+    if (current.status === "working") return true;
+    this.setCurrent(id, "working", taskEpoch, current.agent ?? stream.agent);
+    return true;
+  }
+
+  /**
    * Mark an exact in-flight task as blocked on a user decision or input.
    *
    * A question reaches this from "done" as well as from "working": agents idle

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -683,7 +683,7 @@ const http = createServer((req, res) => {
           id.length > 256 ||
           !Number.isSafeInteger(taskEpoch) ||
           taskEpoch <= 0 ||
-          (status !== "done" && status !== "error") ||
+          (status !== "done" && status !== "error" && status !== "working") ||
           typeof body?.agentActive !== "boolean"
         ) {
           json(400, {
@@ -691,12 +691,19 @@ const http = createServer((req, res) => {
           });
           return;
         }
-        if (status === "error") {
+        let accepted = true;
+        if (status === "working") {
+          // Live busy evidence retracting a premature completion. Epoch-checked
+          // like the others: only the task the screen was watching may resume,
+          // and only while the pty is still the agent's. The verdict is
+          // reported so a refused client stops re-sending it every frame.
+          accepted = activityTracker.reportWorking(id, taskEpoch);
+        } else if (status === "error") {
           activityTracker.reportBlocked(id, taskEpoch);
         } else {
           activityTracker.reportIdle(id, taskEpoch, body.agentActive);
         }
-        json(200, { ok: true, ...activityPayload() });
+        json(200, { ok: true, accepted, ...activityPayload() });
       })
       .catch(fail);
     return;

--- a/apps/web/src/terminal/agentActivityPrompt.test.ts
+++ b/apps/web/src/terminal/agentActivityPrompt.test.ts
@@ -49,6 +49,31 @@ test("a spinner line keeps Claude Code working even with an unknown verb", () =>
   assert.equal(agentBusyScreenVisible(screen("claude-busy-tokens")), true);
 });
 
+test("every spinner frame Claude Code cycles reads as busy", () => {
+  // Observed live: the spinner cycles · ✢ ✳ ∗ ✻ ✽, and only half of those
+  // were in the glyph class. A stall on a wrong frame let the quiet window
+  // finish a running task: replaying the recorded turn, 83 of its 85
+  // stall-exposed moments had exactly such a spinner row on screen.
+  for (const frame of ["·", "✢", "✳", "∗", "✻", "✽"]) {
+    assert.equal(
+      agentBusyScreenVisible(`${frame} Billowing… (30m 38s · ↓ 78.3k tokens)`),
+      true,
+      `spinner frame ${frame} must read as busy`,
+    );
+  }
+});
+
+test("a tool row's truncation ellipsis is not busy", () => {
+  // ⏺ rows outlive the tool call that painted them, and long arguments
+  // truncate with a mid-row ellipsis. Counting ⏺ as a spinner would pin the
+  // dot amber for as long as such a row stays on screen, so it is left out:
+  // while a tool runs, the real spinner row below it carries the turn.
+  assert.equal(
+    agentBusyScreenVisible("⏺ Read(/Users/oldcai/programs/…/manager.ts)"),
+    false,
+  );
+});
+
 test("Claude Code's finished summary line is not busy", () => {
   // "✻ Sautéed for 2s" reports elapsed time after the answer landed.
   assert.equal(agentBusyScreenVisible(screen("claude-answered")), false);

--- a/apps/web/src/terminal/agentActivityPrompt.ts
+++ b/apps/web/src/terminal/agentActivityPrompt.ts
@@ -66,8 +66,14 @@ const ASCII_PROMPT_SCAN_ROWS = 6;
 const CONFIRMATION_PROMPT_SCAN_ROWS = 14;
 const BUSY_SCAN_ROWS = 12;
 const SHELL_PROMPT_MAX_CHARS = 96;
-/** Spinner glyphs: bullets, the sparkle block agents cycle, and braille. */
-const SPINNER_GLYPHS = "•●◦✳-✿⠁-⣿";
+/**
+ * Spinner glyphs: bullets, the frames Claude Code actually cycles (· ✢ ✳ ∗ ✻
+ * ✽ — observed live; only the last four sit in the U+2733–273F block), and
+ * braille. ⏺ is deliberately absent: tool rows outlive the call that painted
+ * them and truncate long arguments with a mid-row ellipsis, which would pin
+ * the dot amber for as long as such a row stays on screen.
+ */
+const SPINNER_GLYPHS = "•●◦·✢∗✳-✿⠁-⣿";
 /** The one busy marker agents spell out in words rather than glyphs. */
 const BUSY_INTERRUPT_RE =
   /\b(?:esc|escape|ctrl(?:\+|-)?c)\s+to\s+(?:interrupt|cancel|stop)\b/i;

--- a/apps/web/src/terminal/agentIdleWatcher.test.ts
+++ b/apps/web/src/terminal/agentIdleWatcher.test.ts
@@ -27,6 +27,24 @@ type Report = { atMs: number; status: string; agentActive: boolean };
 const TURN_ENDED_MS = turn.chunks[turn.chunks.length - 1][0];
 const CLOCK_TICK_MS = 1_000;
 
+/**
+ * The recording is truncated: its last chunk still paints the live spinner
+ * ("✢ Photosynthesizing…"), so the bytes never witness the turn's end. The
+ * suite used to treat that busy tail as the finish line anyway — and passed,
+ * because ✢ sat outside the spinner glyph class, which is exactly the hole
+ * that let a stalled agent read as finished. The settle repaint is therefore
+ * supplied from a real captured settled screen, and completion is asserted
+ * against that moment rather than against the recording running out.
+ */
+const SETTLED_SCREEN = readFileSync(
+  fileURLToPath(
+    new URL("./fixtures/agent-screens/claude-answered.txt", import.meta.url),
+  ),
+  "utf8",
+);
+const SETTLE_REPAINT_MS = 100;
+const SETTLED_AT_MS = TURN_ENDED_MS + SETTLE_REPAINT_MS;
+
 /** What a status bar or right-hand prompt paints at a given moment. */
 function clockRow(atMs: number): string {
   const seconds = Math.floor(atMs / 1000);
@@ -52,35 +70,52 @@ async function replay(quietMs: number, withClock = false): Promise<Report[]> {
 
   // A clock keeps repainting after the agent stops, which is the whole point:
   // its ticks are what used to push the quiet window out forever.
-  const events: { atMs: number; chunk?: string }[] = turn.chunks.map(
-    ([atMs, base64]) => ({ atMs, chunk: base64 }),
-  );
+  const events: { atMs: number; chunk?: string; settle?: boolean }[] =
+    turn.chunks.map(([atMs, base64]) => ({ atMs, chunk: base64 }));
+  events.push({ atMs: SETTLED_AT_MS, settle: true });
   if (withClock) {
-    for (let t = 0; t <= TURN_ENDED_MS + 5 * CLOCK_TICK_MS; t += CLOCK_TICK_MS) {
+    for (let t = 0; t <= SETTLED_AT_MS + 5 * CLOCK_TICK_MS; t += CLOCK_TICK_MS) {
       events.push({ atMs: t });
     }
-    events.sort((a, b) => a.atMs - b.atMs || (a.chunk ? -1 : 1));
   }
+  // Ranked, not signed by `a` alone: a comparator that answers -1 both ways
+  // round reorders the recorded chunks that share a timestamp, and the replay
+  // stops being the session it was captured from.
+  events.sort(
+    (a, b) =>
+      a.atMs - b.atMs ||
+      (a.chunk || a.settle ? 0 : 1) - (b.chunk || b.settle ? 0 : 1),
+  );
 
+  let settledText: string | null = null;
   for (let i = 0; i < events.length; i++) {
-    const { atMs, chunk } = events[i];
+    const { atMs, chunk, settle } = events[i];
     if (chunk) {
       await new Promise<void>((resolve) =>
         term.write(Buffer.from(chunk, "base64"), () => resolve()),
       );
     }
+    if (settle) settledText = SETTLED_SCREEN;
     const buf = term.buffer.active;
-    const start = Math.max(0, buf.viewportY);
-    const lines: string[] = [];
-    for (let y = start; y < Math.min(buf.length, start + term.rows); y++) {
-      lines.push(buf.getLine(y)?.translateToString(true) ?? "");
+    let lines: string[];
+    let cursorLine: string;
+    if (settledText !== null) {
+      lines = settledText.split("\n");
+      cursorLine = "❯ ";
+    } else {
+      const start = Math.max(0, buf.viewportY);
+      lines = [];
+      for (let y = start; y < Math.min(buf.length, start + term.rows); y++) {
+        lines.push(buf.getLine(y)?.translateToString(true) ?? "");
+      }
+      cursorLine =
+        buf.getLine(buf.baseY + buf.cursorY)?.translateToString(true).trimEnd() ?? "";
     }
     if (withClock) lines.push(clockRow(atMs));
     watcher.update(
       {
         visible: lines.join("\n"),
-        cursorLine:
-          buf.getLine(buf.baseY + buf.cursorY)?.translateToString(true).trimEnd() ?? "",
+        cursorLine,
         isAlternate: buf.type === "alternate",
       },
       atMs,
@@ -108,13 +143,19 @@ test("replaying a real turn never finishes it while the agent is still working",
 
 test("replaying a real turn does finish it once the screen settles", async () => {
   const reports = await replay(AGENT_IDLE_QUIET_MS);
+  // Nothing may fire off the recording's busy tail; the settle repaint is
+  // what ends the turn, and the quiet window runs from there.
   const final = reports.filter((r) => r.atMs >= TURN_ENDED_MS);
   assert.ok(final.length > 0, "never reported the finished turn");
+  assert.ok(
+    final[0].atMs >= SETTLED_AT_MS,
+    `reported at ${final[0].atMs}ms, before the settle repaint at ${SETTLED_AT_MS}ms`,
+  );
   assert.equal(final[0].status, "done");
   assert.equal(final[0].agentActive, true, "Claude Code stays open at its composer");
   assert.ok(
-    final[0].atMs - TURN_ENDED_MS <= AGENT_IDLE_QUIET_MS + 50,
-    `took ${final[0].atMs - TURN_ENDED_MS}ms to settle`,
+    final[0].atMs - SETTLED_AT_MS <= AGENT_IDLE_QUIET_MS + 50,
+    `took ${final[0].atMs - SETTLED_AT_MS}ms to settle`,
   );
 });
 
@@ -122,13 +163,13 @@ test("a clock ticking beside the agent does not hold the turn open", async () =>
   // The regression this guards: the watcher used to restart its wait on every
   // PTY write, so one repainting clock row meant the dot never went green.
   const reports = await replay(AGENT_IDLE_QUIET_MS, true);
-  const final = reports.filter((r) => r.atMs >= TURN_ENDED_MS);
+  const final = reports.filter((r) => r.atMs >= SETTLED_AT_MS);
   assert.ok(final.length > 0, "the clock kept the turn from ever finishing");
   assert.equal(final[0].status, "done");
   assert.equal(final[0].agentActive, true);
   assert.ok(
-    final[0].atMs - TURN_ENDED_MS <= AGENT_IDLE_QUIET_MS + CLOCK_TICK_MS,
-    `took ${final[0].atMs - TURN_ENDED_MS}ms to settle`,
+    final[0].atMs - SETTLED_AT_MS <= AGENT_IDLE_QUIET_MS + CLOCK_TICK_MS,
+    `took ${final[0].atMs - SETTLED_AT_MS}ms to settle`,
   );
 });
 
@@ -142,13 +183,77 @@ test("a clock does not finish a turn early either", async () => {
   );
 });
 
-test("the previous 200ms window is what let turns finish early", async () => {
-  // Anchors the regression: the bug was the threshold, not the screen reading.
-  const premature = (await replay(200)).filter(
-    (r) => r.atMs > 0 && r.atMs < TURN_ENDED_MS,
+// The old "a 200ms window fires mid-turn" anchor is gone from this file on
+// purpose: it only fired because half the spinner frames escaped the glyph
+// class and let the watcher arm mid-turn. With the class complete, the busy
+// veto contains even a 200ms window here. The threshold's rationale is still
+// pinned by the write-timing tests in agentActivityPrompt.test.ts, which
+// measure the raw repaint gaps no busy row is around to veto.
+
+/**
+ * The green dot can only be wrong in one direction the latch cannot undo, so
+ * the watcher must never be armed while the agent's spinner is on screen. It
+ * was: the glyph class covered half of Claude Code's spinner frames, so a
+ * stall past the quiet window on a wrong frame (· or ✢) finished the task.
+ */
+const SPINNER_ROW_ORACLE = /^[\s│]*[·✢✳∗✻✽][^\n]{0,80}…/;
+
+test("a stall on a spinner-bearing frame cannot finish the turn", async () => {
+  const term = new Terminal({ cols: turn.cols, rows: turn.rows, allowProposedApi: true });
+  const watcher = new AgentIdleWatcher(AGENT_IDLE_QUIET_MS);
+  const exposed: number[] = [];
+  for (const [atMs, base64] of turn.chunks) {
+    await new Promise<void>((resolve) =>
+      term.write(Buffer.from(base64, "base64"), () => resolve()),
+    );
+    const buf = term.buffer.active;
+    const start = Math.max(0, buf.viewportY);
+    const lines: string[] = [];
+    for (let y = start; y < Math.min(buf.length, start + term.rows); y++) {
+      lines.push(buf.getLine(y)?.translateToString(true) ?? "");
+    }
+    watcher.update(
+      {
+        visible: lines.join("\n"),
+        cursorLine:
+          buf.getLine(buf.baseY + buf.cursorY)?.translateToString(true).trimEnd() ?? "",
+        isAlternate: buf.type === "alternate",
+      },
+      atMs,
+    );
+    if (atMs <= 0 || atMs >= TURN_ENDED_MS) continue;
+    if (watcher.pending === null) continue;
+    if (lines.some((line) => SPINNER_ROW_ORACLE.test(line.trim()))) {
+      exposed.push(atMs);
+    }
+  }
+  assert.deepEqual(
+    exposed,
+    [],
+    `armed on ${exposed.length} spinner-bearing frame(s), first at ${exposed[0]}ms — a 2s stall there turns the dot green mid-turn`,
   );
-  assert.ok(
-    premature.length > 10,
-    `expected the old window to fire mid-turn, got ${premature.length}`,
+});
+
+test("busy evidence is exposed to the caller while it vetoes arming", () => {
+  // The ledger needs it to retract a premature completion: a settled status
+  // contradicted by a live busy screen means the task never actually ended.
+  const watcher = new AgentIdleWatcher();
+  watcher.update(
+    { visible: "✻ Simmering… (1s · ↑ 1 tokens)\n❯ ", cursorLine: "", isAlternate: false },
+    0,
   );
+  const busy = watcher.pending;
+  assert.equal(watcher.busyVisible, true);
+  assert.equal(busy, null);
+
+  watcher.update(
+    { visible: "✻ Sautéed for 2s\n❯ ", cursorLine: "", isAlternate: false },
+    100,
+  );
+  const settled = watcher.pending;
+  assert.equal(watcher.busyVisible, false);
+  assert.equal(settled?.status, "done");
+
+  watcher.reset(false);
+  assert.equal(watcher.busyVisible, false);
 });

--- a/apps/web/src/terminal/agentIdleWatcher.ts
+++ b/apps/web/src/terminal/agentIdleWatcher.ts
@@ -30,6 +30,7 @@ export class AgentIdleWatcher {
   private sawInputPrompt = false;
   private armedSignature: string | null = null;
   private armed: { at: number; transition: AgentScreenTransition } | null = null;
+  private lastBusyVisible = false;
 
   constructor(private readonly quietMs: number = AGENT_IDLE_QUIET_MS) {}
 
@@ -60,21 +61,36 @@ export class AgentIdleWatcher {
     return this.armed?.transition ?? null;
   }
 
+  /**
+   * Whether the latest screen carried positive busy evidence. The veto that
+   * keeps a busy screen from arming the quiet window doubles as the ledger's
+   * proof that a settled status was settled too early: an agent repainting
+   * its spinner did not finish, whatever the dot says.
+   */
+  get busyVisible(): boolean {
+    return this.lastBusyVisible;
+  }
+
   /** A new task on the same session starts from a clean slate. */
   reset(isAlternate: boolean): void {
     this.sawAlternate = isAlternate;
     this.sawInputPrompt = false;
     this.armed = null;
     this.armedSignature = null;
+    this.lastBusyVisible = false;
   }
 
   private transition(view: AgentScreenView): AgentScreenTransition | null {
+    this.lastBusyVisible = false;
     if (!view.visible.trim()) return null;
     if (view.isAlternate) this.sawAlternate = true;
     if (agentConfirmationPromptVisible(view.visible, view.cursorLine)) {
       return { status: "error", agentActive: true };
     }
-    if (agentBusyScreenVisible(view.visible)) return null;
+    if (agentBusyScreenVisible(view.visible)) {
+      this.lastBusyVisible = true;
+      return null;
+    }
 
     const inputPrompt = agentInputPromptVisible(view.visible);
     if (inputPrompt) this.sawInputPrompt = true;

--- a/apps/web/src/terminal/manager.ts
+++ b/apps/web/src/terminal/manager.ts
@@ -263,8 +263,11 @@ let agentActivityRevision = -1;
 const retiredAgentActivityInstances = new Set<string>();
 const agentIdleTimers = new Map<string, { timer: number; deadline: number }>();
 const agentIdleReports = new Map<string, number>();
+const agentResumeReports = new Map<string, number>();
 const agentIdleWatchers = new Map<string, AgentIdleWatcher>();
 const agentReportedInactiveEpochs = new Map<string, number>();
+/** Epochs this client's own quiet window settled — the only ones it may retract. */
+const agentRetractableEpochs = new Map<string, number>();
 const agentTaskStartScreens = new Map<
   string,
   { taskEpoch: number; signature: string }
@@ -495,10 +498,12 @@ function startLocalAgentActivity(
   const session = sessions.get(id);
   clearAgentIdleTimer(id);
   agentIdleReports.delete(id);
+  agentResumeReports.delete(id);
   agentIdleWatcher(id).reset(
     session?.term.buffer.active.type === "alternate",
   );
   agentReportedInactiveEpochs.delete(id);
+  agentRetractableEpochs.delete(id);
   agentTaskStartScreens.set(id, {
     taskEpoch: nextEpoch,
     signature: sessionScreenSignature(id),
@@ -540,15 +545,35 @@ function observeScreenForActivity(id: string): RenderedAgentTransition | null {
 function completeAgentActivityIfIdle(id: string) {
   const activity = agentActivities.get(id);
   const session = sessions.get(id);
-  if (
-    !activity ||
-    !session ||
-    (activity.status !== "working" && activity.status !== "done")
-  ) {
+  if (!activity || !session) {
     clearAgentIdleTimer(id);
     return;
   }
   const transition = observeScreenForActivity(id);
+  // A settled status contradicted by fresh busy evidence was settled too
+  // early: the agent stalled past the quiet window and is still working the
+  // exact same task. Only a completion this quiet window itself produced, on
+  // a screen the agent still owned, may be taken back that way — a done the
+  // pty proved (an agent that exited, an OSC report) is not the screen's to
+  // overturn, and a question waiting on a person is never demoted to work in
+  // progress. Only the live screen may say so — a viewport scrolled into
+  // history replays old spinner rows, hence the follow guard.
+  if (
+    activity.status === "done" &&
+    agentRetractableEpochs.get(id) === activity.taskEpoch &&
+    agentReportedInactiveEpochs.get(id) !== activity.taskEpoch &&
+    transition === null &&
+    agentIdleWatcher(id).busyVisible &&
+    session.followOutput
+  ) {
+    clearAgentIdleTimer(id);
+    resumeAgentActivity(id, activity);
+    return;
+  }
+  if (activity.status !== "working" && activity.status !== "done") {
+    clearAgentIdleTimer(id);
+    return;
+  }
   const start = agentTaskStartScreens.get(id);
   // A task the agent has not answered on screen yet concludes nothing: the
   // composer it was submitted from still looks exactly like an idle one.
@@ -612,6 +637,11 @@ function completeAgentActivityIfIdle(id: string) {
       ) {
         return;
       }
+      // Settled by this quiet window, on a screen the agent still owned: the
+      // one shape of completion live busy evidence is allowed to take back.
+      if (confirmed.status === "done" && confirmed.agentActive) {
+        agentRetractableEpochs.set(id, observedEpoch);
+      }
       if (isDemo) {
         if (latest.status === "working" || confirmed.status === "error") {
           setAgentActivity(
@@ -650,6 +680,73 @@ function completeAgentActivityIfIdle(id: string) {
       }
     }, Math.max(0, deadline - Date.now())),
   });
+}
+
+/**
+ * Pull a prematurely settled task back to working: the screen is repainting
+ * busy evidence for the same epoch, so it never actually finished. This is
+ * the user's manual recovery — pressing Enter to force yellow — made
+ * automatic and side-effect free: same epoch rather than a new task, and no
+ * bytes written to the pty, so the agent is never fed a stray newline.
+ * Local first, so the dot recovers ahead of the server round-trip.
+ */
+function resumeAgentActivity(id: string, activity: AgentActivity) {
+  if (agentResumeReports.get(id) === activity.taskEpoch) return;
+  agentResumeReports.set(id, activity.taskEpoch);
+  // One retraction per completion this quiet window settled: spending the mark
+  // here keeps a later authoritative done for the same epoch — an OSC report,
+  // an agent that exited — out of reach of a stale busy row, and keeps a
+  // refusal from re-firing on every rendered frame. Put back below when the
+  // report never reached the server.
+  agentRetractableEpochs.delete(id);
+  setAgentActivity(id, "working", activity.agent, activity.taskEpoch);
+  if (isDemo) {
+    agentResumeReports.delete(id);
+    return;
+  }
+  void (async () => {
+    let accepted = false;
+    let answered = false;
+    try {
+      const response = await fetch(`${apiUrl()}/api/activity/report`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          id,
+          taskEpoch: activity.taskEpoch,
+          status: "working",
+          agentActive: true,
+        }),
+      });
+      if (response.ok) {
+        const payload = await readJsonResponse(response);
+        // The server refuses a session whose pty the shell already took back,
+        // and says so: a refusal is an answer, not a lost report.
+        answered = true;
+        accepted = payload?.accepted !== false;
+        applyAgentActivityPayload(payload);
+      }
+    } catch {
+      // Put back below, so the next rendered write retries the retraction.
+    } finally {
+      const latest = agentActivities.get(id);
+      const sameTask = latest?.taskEpoch === activity.taskEpoch;
+      // A refused or unsent retraction has to give the optimistic yellow back,
+      // or the entry condition above stays false and the retry never comes.
+      if (!accepted && sameTask && latest?.status === "working") {
+        setAgentActivity(id, activity.status, activity.agent, activity.taskEpoch);
+      }
+      // Only a report that never got an answer is worth asking again; a
+      // refusal stands, or the dot strobes against a server that keeps saying
+      // no on every frame.
+      if (!answered && sameTask) {
+        agentRetractableEpochs.set(id, activity.taskEpoch);
+      }
+      if (agentResumeReports.get(id) === activity.taskEpoch) {
+        agentResumeReports.delete(id);
+      }
+    }
+  })();
 }
 
 function updateAgentActivityFromOutput(id: string, data: string) {
@@ -1919,8 +2016,10 @@ export function disposeSession(id: string) {
   notifyConnectionStatus();
   clearAgentIdleTimer(id);
   agentIdleReports.delete(id);
+  agentResumeReports.delete(id);
   agentIdleWatchers.delete(id);
   agentReportedInactiveEpochs.delete(id);
+  agentRetractableEpochs.delete(id);
   agentTaskStartScreens.delete(id);
   terminalInputSendChains.delete(id);
   commandSendChains.delete(id);
@@ -1954,8 +2053,10 @@ export function disposePaneSessions(paneId: string) {
     restoreSnapshots.delete(id);
     clearAgentIdleTimer(id);
     agentIdleReports.delete(id);
+    agentResumeReports.delete(id);
     agentIdleWatchers.delete(id);
     agentReportedInactiveEpochs.delete(id);
+    agentRetractableEpochs.delete(id);
     agentTaskStartScreens.delete(id);
     terminalInputSendChains.delete(id);
     commandSendChains.delete(id);


### PR DESCRIPTION
## 问题

Agent 还在干活，绿点却提前亮了 —— 而且此后再也变不回黄。整个任务后半程，会话一直显示「已完成」，只有手动敲一次回车才能救活。

## 原因

两个独立的问题叠在一起：

1. **quiet window 把「停顿」当成了「结束」。** 客户端靠「屏幕安静了一段时间」判定 agent 空闲。Agent 思考、等网络、跑长工具调用时的停顿只要超过这个窗口，账本就被 settle 成 `done`。调大 `AGENT_IDLE_QUIET_MS` 治不了这个病：实测最差重绘 gap 只有 457ms，2s 已经有 4.4x 余量，加大窗口只会把稳定复现变成间歇性。

2. **绿灯是锁存状态，输出无权把它变回黄。** 状态机里压根没有 output → working 这条边 —— 这是刻意的，为了防止后续输出吞掉用户还没读到的完成通知。代价是：一旦误判成绿，屏幕上转轮转得再欢也收不回来，因为用户手敲回车走的是「新任务」通道，那是唯一的活路。

放大这两条的还有 `SPINNER_GLYPHS`：它原先只盖住 Claude Code 实际循环的六个转轮帧（`·` `✢` `✳` `∗` `✻` `✽`）的一半，所以本该否决 quiet window 的忙证据经常压根识别不到。

## 解决办法

核心是给锁存加一条**同 epoch 的回退边**：屏幕正在重绘忙证据 ⇒ 这个任务根本没结束 ⇒ 把它拉回 `working`。难点在于「谁有权撤销」，因为不能让一行残留的转轮推翻真正的完成。

- `agentIdleWatcher` 暴露 `busyVisible`。这个信号本来就在否决 quiet window 的 arm，现在同时充当「刚才那次 settle 太早了」的证据 —— 不新增任何启发式。

- `manager` 用 `agentRetractableEpochs` 记下**哪些 epoch 是它自己的 quiet window 判定的**，只有这些才可撤销。pty 证明过的 done（OSC 上报、agent 进程退出）不归屏幕管。同时要求 `session.followOutput`：视口滚进历史时会重放旧的转轮行，那不是实时证据。

- `resumeAgentActivity()` 对该 epoch 上报 `status: "working"`，先改本地再走服务端，**不往 pty 写任何字节** —— 等于把用户手敲回车的救活操作自动化，但不会喂给 agent 一个多余的换行。这个授权在服务端**应答后即失效**（无论接受还是拒绝），所以：晚到的权威 done 不会被覆盖，被拒绝的上报也不会每帧重发。只有请求根本没送达时才归还授权，让下一帧重试。

- `/api/activity/report` 接受 `status: "working"`，并回传 `accepted`，让被拒绝的客户端知道该停手。服务端 `reportWorking()` 同时校验 epoch 和归属（`stream.agentActive`）—— shell 已经收回的 pty 不会被一行还留在屏上的转轮重新认领。

- `SPINNER_GLYPHS` 补上漏掉的 `·` `✢` `∗`。`⏺` 故意不加：工具行在调用结束后仍留在屏上，且会截断出行中省略号，加了会把绿点永久卡成黄的。

红点（`error`）同样受益：纯按键菜单没有输入事件可循，答完之后的忙屏幕是唯一证据，现在能自动回黄了。

## 验证

- 新增 `apps/server/src/agentActivity.test.ts`，覆盖 `reportWorking` 的 epoch / 归属守卫
- `agentIdleWatcher` 与 `agentActivityPrompt` 的用例扩展到回退路径；录制回放里「卡 2 秒即误判完成」的暴露帧 85 → 2
- `npm -w @termany/server run test` 72/72 通过
- `npm -w @termany/web run test` 148/148 通过
- `tsc --noEmit` 通过
