### PR TITLE
修复 Pane 焦点与光标不同步问题

### DIFF
--- a/apps/web/src/components/AgentHistory.tsx
+++ b/apps/web/src/components/AgentHistory.tsx
@@ -145,6 +145,12 @@ export function AgentHistory({ autoFocus = false }: { autoFocus?: boolean }) {
   const listRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
+  useEffect(() => {
+    if (!autoFocus) return;
+    const frame = requestAnimationFrame(() => inputRef.current?.focus({ preventScroll: true }));
+    return () => cancelAnimationFrame(frame);
+  }, [autoFocus]);
+
   const agentName = agents.find((a) => a.id === agentId)?.name ?? agentId;
 
   // Resolve the scope once: repo worktrees first, plain directory as fallback.

--- a/apps/web/src/components/AgentPane.tsx
+++ b/apps/web/src/components/AgentPane.tsx
@@ -6,7 +6,14 @@ import { agentModelSetup } from "../agentModelSetup";
 import { apiPath } from "../api";
 import { useI18n } from "../i18n";
 import { useImeGuard } from "../imeGuard";
-import { cwdCandidates, useStore, type AgentMessage, type AgentPart, type Pane } from "../state/store";
+import {
+  activeHtab,
+  cwdCandidates,
+  useStore,
+  type AgentMessage,
+  type AgentPart,
+  type Pane,
+} from "../state/store";
 import { queueCommand } from "../terminal/manager";
 import { CheckIcon, ChevronIcon, CopyIcon, FolderIcon, SendIcon, SpinnerIcon, StopIcon, TerminalIcon } from "./icons";
 import { Markdown } from "./Markdown";
@@ -157,7 +164,7 @@ function AgentSteps({
   );
 }
 
-export function AgentPane({ leaf }: { leaf: Leaf }) {
+export function AgentPane({ leaf, focused = false }: { leaf: Leaf; focused?: boolean }) {
   const { t } = useI18n();
   const setAgentMessages = useStore((s) => s.setAgentMessages);
   const setAgentModel = useStore((s) => s.setAgentModel);
@@ -183,6 +190,12 @@ export function AgentPane({ leaf }: { leaf: Leaf }) {
   const ime = useImeGuard();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const endRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!focused) return;
+    const frame = requestAnimationFrame(() => textareaRef.current?.focus({ preventScroll: true }));
+    return () => cancelAnimationFrame(frame);
+  }, [focused]);
 
   useEffect(() => {
     if (!streamingRef.current) setMessages(leaf.agentMessages ?? []);
@@ -461,7 +474,14 @@ export function AgentPane({ leaf }: { leaf: Leaf }) {
       setPermission(null);
       streamingRef.current = false;
       abortRef.current = null;
-      requestAnimationFrame(() => textareaRef.current?.focus());
+      // A reply can finish after the user moved to another pane. Never let an
+      // async completion create a second, DOM-only focus that disagrees with
+      // the canonical pane selection and its ring.
+      requestAnimationFrame(() => {
+        if (activeHtab(useStore.getState())?.focused === leaf.id) {
+          textareaRef.current?.focus();
+        }
+      });
     }
   };
 

--- a/apps/web/src/components/SplitView.tsx
+++ b/apps/web/src/components/SplitView.tsx
@@ -11,7 +11,7 @@ import {
   aggregateAgentActivity,
   agentActivitySnapshot,
   agentActivityTitle,
-  focusSession,
+  reconcileTerminalFocus,
   subscribeAgentActivity,
   terminalSessionId,
 } from "../terminal/manager";
@@ -61,6 +61,18 @@ function findLeaf(pane: Pane, id: string): Leaf | undefined {
     if (hit) return hit;
   }
   return undefined;
+}
+
+/**
+ * Structure-only identity for focus reconciliation. Split sizes deliberately
+ * stay out so divider dragging does not refocus on every frame; changes that
+ * can remount a PaneSlot (split/collapse/reorder/view/SSH) remain visible.
+ */
+function focusTopologyKey(pane: Pane): string {
+  if (pane.kind === "leaf") {
+    return JSON.stringify([pane.id, pane.view ?? "terminal", pane.sshTarget ?? ""]);
+  }
+  return `${pane.dir}(${pane.children.map(focusTopologyKey).join(",")})`;
 }
 
 /** Pick the nearest edge of a rect for the given cursor point. */
@@ -385,7 +397,10 @@ function PaneHeader({
             // Don't let the slot's mousedown focus a pane we're about to close:
             // it would make closing ANY pane look like closing the focused one,
             // and focus would leave the pane the user was actually working in.
-            onMouseDown={(e) => e.stopPropagation()}
+            onMouseDown={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+            }}
             onClick={() => closePane(leaf.id)}
           >
             <CloseIcon />
@@ -417,22 +432,33 @@ function PaneSlot({
   const setFocusedPane = useStore((s) => s.setFocusedPane);
   const setPaneWebUrl = useStore((s) => s.setPaneWebUrl);
   const dropEdge = dropTarget?.id === leaf.id ? dropTarget.edge : null;
+  const isTerminal = (leaf.view ?? "terminal") === "terminal";
 
   useEffect(() => {
-    if (focused) {
-      focusSession(leaf.id);
-      acknowledgeAgentActivities([leaf.id]);
-    }
+    if (focused) acknowledgeAgentActivities([leaf.id]);
   }, [focused, leaf.id]);
+
+  const focusPane = () => {
+    // Update the one canonical state first; the ring and every later focus
+    // reconciliation now point at the same pane. The direct terminal focus is
+    // needed even when this pane was already selected (e.g. after a header
+    // control temporarily owned DOM focus).
+    setFocusedPane(leaf.id);
+    if (isTerminal) reconcileTerminalFocus(leaf.id);
+    acknowledgeAgentActivities([leaf.id]);
+  };
 
   return (
     <div
       data-pane-id={leaf.id}
-      className={`pane-slot ${showFocus && focused ? "focused" : ""}`}
-      onMouseDown={() => {
-        setFocusedPane(leaf.id);
-        acknowledgeAgentActivities([leaf.id]);
-      }}
+      // `focused` always mirrors the canonical store state. Whether a ring is
+      // useful is a separate presentation concern (single/zen panes omit it).
+      className={`pane-slot${focused ? " focused" : ""}${showFocus ? " show-focus-ring" : ""}`}
+      onMouseDown={focusPane}
+      // Keyboard navigation and child auto-focus can enter a pane without a
+      // mouse event. Feed that fact back into the same canonical state so the
+      // ring can never stay behind in another pane.
+      onFocusCapture={() => setFocusedPane(leaf.id)}
     >
       <PaneHeader
         leaf={leaf}
@@ -461,9 +487,10 @@ function PaneSlot({
             id={leaf.id}
             initialUrl={leaf.webUrl}
             onUrlChange={(url) => setPaneWebUrl(leaf.id, url)}
+            focused={focused}
           />
         ) : leaf.view === "agent" ? (
-          <AgentPane leaf={leaf} />
+          <AgentPane leaf={leaf} focused={focused} />
         ) : (
           <TerminalPane id={leaf.id} sshTarget={leaf.sshTarget} />
         )}
@@ -684,6 +711,19 @@ export function SplitView({ htab }: { htab: HTab }) {
   const newHTabDropRef = useRef(false);
   // Dropped on a sidebar page row → new tab on that page.
   const nodeDropTargetRef = useRef<string | null>(null);
+  const focusedLeaf = htab.focused ? findLeaf(htab.layout, htab.focused) : undefined;
+  const focusedTerminalId =
+    focusedLeaf && (focusedLeaf.view ?? "terminal") === "terminal" ? focusedLeaf.id : undefined;
+  const focusTopology = focusTopologyKey(htab.layout);
+
+  // TerminalPane attaches sessions in child effects before this parent effect
+  // runs. Reconcile from canonical focus after every tab/topology/zoom change;
+  // individual PaneSlots must not race focus against blur. The topology key
+  // also covers closing an unfocused sibling, where the focused id stays the
+  // same but React may remount its surviving PaneSlot while collapsing splits.
+  useEffect(() => {
+    reconcileTerminalFocus(focusedTerminalId);
+  }, [htab.id, htab.maximized, focusedTerminalId, focusTopology]);
 
   const updateDropTarget = (next: PaneDropTarget) => {
     dropTargetRef.current = next;

--- a/apps/web/src/components/TerminalPane.tsx
+++ b/apps/web/src/components/TerminalPane.tsx
@@ -3,8 +3,8 @@ import {
   attachSession,
   detachSession,
   fitSession,
-  focusSession,
   noteManualScroll,
+  reconcileTerminalFocus,
   scrollSessionToBottom,
   scrollSessionToTop,
   subscribeTerminalScrollState,
@@ -13,6 +13,7 @@ import {
   type TerminalScrollState,
 } from "../terminal/manager";
 import { subscribeDesktopFileDrops } from "../terminal/desktopFileDrop";
+import { reconcileAttachedTerminalFocus } from "../terminal/focusHandoff";
 import { activeHtab, cwdCandidates, useStore } from "../state/store";
 import { openLocalPathsInSession } from "../terminal/openLocalPath";
 import { ChevronIcon } from "./icons";
@@ -78,9 +79,6 @@ export function TerminalPane({ id, sshTarget }: { id: string; sshTarget?: string
   useEffect(() => {
     const host = hostRef.current;
     if (!host) return;
-    // Read, don't subscribe: only whether THIS pane owns the keyboard at the
-    // moment it mounts. A pane that remounts because a sibling closed must not
-    // pull focus off the pane the store actually focused.
     const state = useStore.getState();
     attachSession(
       sessionId,
@@ -88,8 +86,21 @@ export function TerminalPane({ id, sshTarget }: { id: string; sshTarget?: string
       cwdCandidates(state, id),
       sshTarget,
       id,
-      activeHtab(state)?.focused === id
     );
+
+    // Attaching is the terminal's readiness boundary. The parent SplitView
+    // normally reconciles after its children mount, but a newly-created pane
+    // must not depend on React's cross-component passive-effect ordering to
+    // receive the keyboard. Project the canonical store focus once now and
+    // once after layout/default browser focus has settled. Re-reading the
+    // store in both passes prevents a stale attach from stealing focus if the
+    // user switched panes in the meantime.
+    const cancelFocusHandoff = reconcileAttachedTerminalFocus(
+      id,
+      () => activeHtab(useStore.getState())?.focused,
+      reconcileTerminalFocus,
+    );
+
     const unsubscribeScrollState = subscribeTerminalScrollState(sessionId, setScrollState);
 
     // Coalesce resize bursts (window/split-drag fires RO every frame) to ONE fit
@@ -106,6 +117,7 @@ export function TerminalPane({ id, sshTarget }: { id: string; sshTarget?: string
     ro.observe(host);
 
     return () => {
+      cancelFocusHandoff();
       if (raf) cancelAnimationFrame(raf);
       ro.disconnect();
       unsubscribeScrollState();
@@ -171,7 +183,6 @@ export function TerminalPane({ id, sshTarget }: { id: string; sshTarget?: string
       <div
         className="term-pane-host"
         ref={hostRef}
-        onMouseDown={() => focusSession(sessionId)}
         onWheel={() => {
           noteManualScroll(sessionId);
           revealScrollJump();

--- a/apps/web/src/components/WebBrowserPane.tsx
+++ b/apps/web/src/components/WebBrowserPane.tsx
@@ -23,10 +23,13 @@ export function WebBrowserPane({
   id,
   initialUrl,
   onUrlChange,
+  focused = false,
 }: {
   id: string;
   initialUrl?: string;
   onUrlChange?: (url: string) => void;
+  /** The same canonical pane selection that draws the focus ring. */
+  focused?: boolean;
 }) {
   const startingUrl = normalizeUrl(initialUrl ?? DEFAULT_URL);
   const [url, setUrl] = useState(startingUrl);
@@ -40,6 +43,7 @@ export function WebBrowserPane({
     () => isTauri && document.body.classList.contains("native-webviews-suppressed"),
   );
   const viewportRef = useRef<HTMLDivElement>(null);
+  const nativeViewRef = useRef<import("@tauri-apps/api/webview").Webview | null>(null);
   // Mount-unique suffix: zen (maximize) toggling remounts this pane, and the
   // fresh webview would otherwise reuse the label of its still-closing
   // predecessor, which rejects the creation.
@@ -122,6 +126,7 @@ export function WebBrowserPane({
           focus: false,
           dragDropEnabled: false,
         });
+        nativeViewRef.current = webview;
         const bringForward = async () => {
           if (cancelled || !webview) return;
           try {
@@ -131,10 +136,9 @@ export function WebBrowserPane({
               return;
             }
             await appWindow.show();
-            await appWindow.setFocus();
-            // show()/focus() cross the native bridge. Suppression may have
-            // changed while the preceding calls were in flight, so check at
-            // the last possible moment before revealing the child view.
+            // show() crosses the native bridge. Suppression may have changed
+            // while the preceding calls were in flight, so check at the last
+            // possible moment before revealing the child view.
             if (!canReveal()) {
               visible = false;
               await webview.hide();
@@ -146,15 +150,9 @@ export function WebBrowserPane({
               await webview.hide();
               return;
             }
-            await webview.setFocus();
-            if (!canReveal()) {
-              visible = false;
-              await webview.hide();
-              return;
-            }
             visible = true;
           } catch (err) {
-            console.warn("Failed to focus webview", err);
+            console.warn("Failed to reveal webview", err);
           }
         };
         void webview.once("tauri://created", async () => {
@@ -167,6 +165,7 @@ export function WebBrowserPane({
         void webview.once<string>("tauri://error", (event) => {
           if (cancelled) return;
           webview = null;
+          nativeViewRef.current = null;
           setNativeState("error");
           setNativeError(event.payload || "Failed to create webview");
         });
@@ -237,8 +236,25 @@ export function WebBrowserPane({
       unsubscribeOcclusion();
       void webview?.hide().catch(() => {});
       void webview?.close();
+      if (nativeViewRef.current === webview) nativeViewRef.current = null;
     };
   }, [label, url]);
+
+  // Revealing a native child view and focusing it are different operations.
+  // Every web pane may mount during a tab switch, but only the pane selected by
+  // the canonical store state may take keyboard focus; otherwise an async
+  // `tauri://created` callback can steal focus long after the terminal ring has
+  // already settled elsewhere.
+  useEffect(() => {
+    if (!isTauri || !focused || nativeState !== "ready" || viewSuppressed) return;
+    const frame = requestAnimationFrame(() => {
+      const host = viewportRef.current;
+      const rect = host?.getBoundingClientRect();
+      if (!host?.isConnected || !rect || rect.width <= 2 || rect.height <= 2) return;
+      void nativeViewRef.current?.setFocus().catch(() => {});
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [focused, nativeState, viewSuppressed]);
 
   return (
     <div className="web-pane">

--- a/apps/web/src/state/paneFocus.ts
+++ b/apps/web/src/state/paneFocus.ts
@@ -1,51 +1,96 @@
 /**
- * Which pane takes the focus ring when another one closes.
+ * Canonical pane-focus state for one horizontal tab.
  *
- * Closing used to hand focus to the tab's very first leaf, which is almost
- * never where the user was looking — close the bottom-right pane of a grid and
- * the ring jumped to the top-left corner. The neighbour is the pane that
- * visually GROWS into the freed space, so that is the one that gets focus.
+ * `focused` is the single source of truth used by both the focus ring and the
+ * content that receives keyboard input. `focusHistory` is only an MRU list of
+ * earlier panes (newest first); it deliberately excludes `focused`, so it is
+ * not a second copy of the current focus.
  *
- * Kept free of runtime imports so it can be exercised directly.
+ * History is optional for backward compatibility with layouts persisted
+ * before it existed. The first focus transition starts recording it.
  */
-import type { Pane } from "./store";
-
-function firstLeaf(pane: Pane): string {
-  return pane.kind === "leaf" ? pane.id : firstLeaf(pane.children[0]);
+export interface PaneFocusState {
+  focused: string;
+  focusHistory?: string[];
 }
 
-function lastLeaf(pane: Pane): string {
-  return pane.kind === "leaf" ? pane.id : lastLeaf(pane.children[pane.children.length - 1]);
+export interface HTabSelection<T extends { id: string }> {
+  activeHTab: string;
+  htabs: T[];
+}
+
+function survivingHistory(
+  state: PaneFocusState,
+  paneIds: readonly string[],
+  exclude: ReadonlySet<string>,
+): string[] {
+  const available = new Set(paneIds);
+  const seen = new Set<string>();
+  const history: string[] = [];
+  for (const paneId of state.focusHistory ?? []) {
+    if (!available.has(paneId) || exclude.has(paneId) || seen.has(paneId)) continue;
+    seen.add(paneId);
+    history.push(paneId);
+  }
+  return history;
+}
+
+function paneFocusState(focused: string, focusHistory: string[]): PaneFocusState {
+  return focusHistory.length ? { focused, focusHistory } : { focused };
 }
 
 /**
- * The leaf that should hold focus once `leafId` is removed from `layout`:
- * its nearest sibling in the split that held it — the one after it, else the
- * one before. Descending a sibling subtree enters it from the touching edge
- * (the next one's first leaf, the previous one's last), so focus lands on the
- * pane that was physically adjacent rather than that subtree's corner.
- *
- * `null` when there is no neighbour to pick: the closed pane was the whole
- * layout, or it isn't in this layout at all. Callers keep their own fallback.
- *
- * Pass the layout as it was BEFORE the removal — the siblings are what makes
- * the choice.
+ * Focus `paneId` and remember the pane the user was actually coming from.
+ * Invalid cross-tab ids are ignored rather than leaving the ring nowhere.
  */
-export function nextFocusAfterClose(layout: Pane, leafId: string): string | null {
-  if (layout.kind === "leaf") return null;
+export function focusPane(
+  state: PaneFocusState,
+  paneId: string,
+  paneIds: readonly string[],
+): PaneFocusState {
+  if (state.focused === paneId || !paneIds.includes(paneId)) return state;
 
-  const i = layout.children.findIndex((c) => c.kind === "leaf" && c.id === leafId);
-  if (i >= 0) {
-    const after = layout.children[i + 1];
-    if (after) return firstLeaf(after);
-    const before = layout.children[i - 1];
-    if (before) return lastLeaf(before);
-    return null; // a one-child split shouldn't exist, but don't invent a pane
-  }
+  const available = new Set(paneIds);
+  const previous = available.has(state.focused) ? [state.focused] : [];
+  const history = survivingHistory(state, paneIds, new Set([paneId, state.focused]));
+  return paneFocusState(paneId, [...previous, ...history]);
+}
 
-  for (const child of layout.children) {
-    const hit = nextFocusAfterClose(child, leafId);
-    if (hit) return hit;
-  }
-  return null;
+/**
+ * Reconcile focus after one pane leaves the tab.
+ *
+ * If the current pane left (or an old persisted id is stale), restore the most
+ * recently focused surviving pane. Only when no history exists do we fall back
+ * to layout order. Removing an unfocused pane leaves current focus untouched
+ * and merely prunes that pane from the fallback history.
+ */
+export function focusPaneAfterRemoval(
+  state: PaneFocusState,
+  removedPaneId: string,
+  remainingPaneIds: readonly string[],
+): PaneFocusState {
+  if (!remainingPaneIds.length) return state;
+
+  const currentSurvives =
+    state.focused !== removedPaneId && remainingPaneIds.includes(state.focused);
+  const history = survivingHistory(
+    state,
+    remainingPaneIds,
+    new Set([removedPaneId, ...(currentSurvives ? [state.focused] : [])]),
+  );
+  const focused = currentSurvives ? state.focused : (history.shift() ?? remainingPaneIds[0]);
+  return paneFocusState(focused, history.filter((paneId) => paneId !== focused));
+}
+
+/**
+ * Switch tabs without rewriting either tab's pane focus or MRU history.
+ * Keeping the tab array by reference is the invariant: returning to a tab
+ * restores exactly the pane that tab already selected.
+ */
+export function selectHTab<T extends { id: string }>(
+  state: HTabSelection<T>,
+  tabId: string,
+): HTabSelection<T> {
+  if (state.activeHTab === tabId || !state.htabs.some((tab) => tab.id === tabId)) return state;
+  return { ...state, activeHTab: tabId };
 }

--- a/apps/web/src/state/store.ts
+++ b/apps/web/src/state/store.ts
@@ -15,7 +15,7 @@ import {
 } from "../rail-config";
 import { claimPage, readWindowPref, writeWindowPref } from "./windows";
 import { stepWorkspace } from "./layoutMerge";
-import { nextFocusAfterClose } from "./paneFocus";
+import { focusPane, focusPaneAfterRemoval, selectHTab } from "./paneFocus";
 import { nextCyclablePaneView } from "./paneViewCycle";
 
 /**
@@ -144,8 +144,15 @@ export interface HTab {
   id: string;
   title: string;
   layout: Pane;
-  /** The focused leaf (session id) — where split/close act and keyboard goes. */
+  /**
+   * The canonical focused leaf (session id). The ring, keyboard target and all
+   * pane actions derive from this same id; imperative DOM focus is never stored
+   * separately.
+   */
   focused: string;
+  /** Earlier focused panes, newest first. Excludes `focused`; optional so old
+   * persisted layouts migrate lazily on their first focus transition. */
+  focusHistory?: string[];
   /** When set, only this leaf is shown, filling the tab (Wave-style magnify). */
   maximized?: string;
   /**
@@ -395,6 +402,31 @@ export function findLeaf(pane: Pane, leafId: string): (Pane & { kind: "leaf" }) 
     if (hit) return hit;
   }
   return undefined;
+}
+
+/** Apply the one canonical focus transition while preserving the rest of a tab. */
+function withFocusedPane(tab: HTab, paneId: string, layout = tab.layout): HTab {
+  const next = focusPane(tab, paneId, leafIds(layout));
+  if (next === tab) return tab;
+  return { ...tab, focused: next.focused, focusHistory: next.focusHistory };
+}
+
+/** Apply a pane removal, including focus history and maximized-pane cleanup. */
+function tabAfterPaneRemoval(tab: HTab, paneId: string, layout: Pane): HTab {
+  const next = focusPaneAfterRemoval(tab, paneId, leafIds(layout));
+  return {
+    ...tab,
+    layout,
+    focused: next.focused,
+    focusHistory: next.focusHistory,
+    maximized: tab.maximized === paneId ? undefined : tab.maximized,
+  };
+}
+
+/** Activate a tab without touching the per-tab pane focus records. */
+function withActiveHTab(node: TreeNode, tabId: string): TreeNode {
+  const next = selectHTab({ activeHTab: node.activeHTab, htabs: node.htabs }, tabId);
+  return next.activeHTab === node.activeHTab ? node : { ...node, activeHTab: next.activeHTab };
 }
 
 /** Where a pane lives, in jumpToResult coordinates. */
@@ -878,9 +910,6 @@ function closeLeaf(s: State, leafId: string): Partial<State> {
   const { workspaceId, nodeId, htab } = home;
   disposePaneSessions(leafId);
   const layout = removeLeaf(htab.layout, leafId);
-  // Resolved against the layout as it stood, so the siblings are still there to
-  // pick from; `removeLeaf` only drops `leafId`, so the neighbour survives it.
-  const neighbor = nextFocusAfterClose(htab.layout, leafId);
   return {
     workspaces: inWs(s.workspaces, workspaceId, (ws) => ({
       ...ws,
@@ -898,12 +927,7 @@ function closeLeaf(s: State, leafId: string): Partial<State> {
           ...n,
           htabs: n.htabs.map((h) => {
             if (h.id !== htab.id) return h;
-            return {
-              ...h,
-              layout,
-              focused: h.focused === leafId ? (neighbor ?? firstLeaf(layout)) : h.focused,
-              maximized: h.maximized === leafId ? undefined : h.maximized,
-            };
+            return tabAfterPaneRemoval(h, leafId, layout);
           }),
         };
       }),
@@ -1161,7 +1185,9 @@ export const useStore = create<State>((set, get) => ({
               activeHTab: tabId,
               htabs: paneId
                 ? n.htabs.map((h) =>
-                    h.id === tabId ? { ...h, focused: paneId, maximized: undefined } : h
+                    h.id === tabId
+                      ? withFocusedPane({ ...h, maximized: undefined }, paneId)
+                      : h
                   )
                 : n.htabs,
             };
@@ -1238,7 +1264,7 @@ export const useStore = create<State>((set, get) => ({
     set((s) => ({
       workspaces: inActiveWs(s, (ws) => ({
         ...ws,
-        roots: updateNode(ws.roots, activeNodeId(s), (n) => ({ ...n, activeHTab: hId })),
+        roots: updateNode(ws.roots, activeNodeId(s), (n) => withActiveHTab(n, hId)),
       })),
     })),
 
@@ -1348,12 +1374,12 @@ export const useStore = create<State>((set, get) => ({
           htabs: n.htabs.map((h) => {
             if (h.id !== n.activeHTab || paneCount(h.layout) >= MAX_PANES_PER_TAB) return h;
             const leaf = makeLeaf(nextPaneTitle(h.layout), h.focused);
-            return {
+            const next = {
               ...h,
               layout: splitPane(h.layout, h.focused, dir, leaf),
-              focused: leaf.id,
               maximized: undefined,
             };
+            return withFocusedPane(next, leaf.id);
           }),
         })),
       })),
@@ -1368,15 +1394,21 @@ export const useStore = create<State>((set, get) => ({
   closePane: (leafId) => set((s) => closeLeaf(s, leafId)),
 
   setFocusedPane: (leafId) =>
-    set((s) => ({
-      workspaces: inActiveWs(s, (ws) => ({
-        ...ws,
-        roots: updateNode(ws.roots, activeNodeId(s), (n) => ({
-          ...n,
-          htabs: n.htabs.map((h) => (h.id === n.activeHTab ? { ...h, focused: leafId } : h)),
+    set((s) => {
+      const active = activeHtab(s);
+      if (!active || active.focused === leafId || !findLeaf(active.layout, leafId)) return s;
+      return {
+        workspaces: inActiveWs(s, (ws) => ({
+          ...ws,
+          roots: updateNode(ws.roots, activeNodeId(s), (n) => ({
+            ...n,
+            htabs: n.htabs.map((h) =>
+              h.id === n.activeHTab ? withFocusedPane(h, leafId) : h
+            ),
+          })),
         })),
-      })),
-    })),
+      };
+    }),
 
   nextHTab: () =>
     set((s) => ({
@@ -1385,7 +1417,7 @@ export const useStore = create<State>((set, get) => ({
         roots: updateNode(ws.roots, activeNodeId(s), (n) => {
           if (n.htabs.length < 2) return n;
           const i = n.htabs.findIndex((h) => h.id === n.activeHTab);
-          return { ...n, activeHTab: n.htabs[(i + 1) % n.htabs.length].id };
+          return withActiveHTab(n, n.htabs[(i + 1) % n.htabs.length].id);
         }),
       })),
     })),
@@ -1397,7 +1429,7 @@ export const useStore = create<State>((set, get) => ({
         roots: updateNode(ws.roots, activeNodeId(s), (n) => {
           if (n.htabs.length < 2) return n;
           const i = n.htabs.findIndex((h) => h.id === n.activeHTab);
-          return { ...n, activeHTab: n.htabs[(i - 1 + n.htabs.length) % n.htabs.length].id };
+          return withActiveHTab(n, n.htabs[(i - 1 + n.htabs.length) % n.htabs.length].id);
         }),
       })),
     })),
@@ -1413,7 +1445,7 @@ export const useStore = create<State>((set, get) => ({
             const ids = leafIds(h.layout);
             if (ids.length < 2) return h;
             const i = ids.indexOf(h.focused);
-            return { ...h, focused: ids[(i + 1) % ids.length] };
+            return withFocusedPane(h, ids[(i + 1) % ids.length]);
           }),
         })),
       })),
@@ -1430,7 +1462,7 @@ export const useStore = create<State>((set, get) => ({
             const ids = leafIds(h.layout);
             if (ids.length < 2) return h;
             const i = ids.indexOf(h.focused);
-            return { ...h, focused: ids[(i - 1 + ids.length) % ids.length] };
+            return withFocusedPane(h, ids[(i - 1 + ids.length) % ids.length]);
           }),
         })),
       })),
@@ -1587,7 +1619,8 @@ export const useStore = create<State>((set, get) => ({
                   ? { ...p, view: "files", filesRoot: root, filesSelected: selectedFile }
                   : p
                 : { ...p, children: p.children.map(open) };
-            return { ...h, layout: open(h.layout), focused: leafId };
+            const layout = open(h.layout);
+            return withFocusedPane({ ...h, layout }, leafId);
           }),
         })),
       })),
@@ -1630,12 +1663,12 @@ export const useStore = create<State>((set, get) => ({
               view,
             };
             created = leaf.id;
-            return {
+            const next = {
               ...h,
               layout: tileLayout(h.layout, leaf),
-              focused: leaf.id,
               maximized: undefined,
             };
+            return withFocusedPane(next, leaf.id);
           }),
         })),
       })),
@@ -1663,7 +1696,10 @@ export const useStore = create<State>((set, get) => ({
           ...n,
           htabs: n.htabs.map((h) =>
             h.id === n.activeHTab
-              ? { ...h, maximized: h.maximized === leafId ? undefined : leafId, focused: leafId }
+              ? withFocusedPane(
+                  { ...h, maximized: h.maximized === leafId ? undefined : leafId },
+                  leafId,
+                )
               : h
           ),
         })),
@@ -1682,12 +1718,12 @@ export const useStore = create<State>((set, get) => ({
             if (!dragged) return h;
             const without = removeLeaf(h.layout, dragId);
             if (!without || !findLeaf(without, targetId)) return h;
-            return {
+            const next = {
               ...h,
               layout: insertBeside(without, targetId, dragged, edge),
-              focused: dragId,
               maximized: undefined,
             };
+            return withFocusedPane(next, dragId);
           }),
         })),
       })),
@@ -1704,7 +1740,6 @@ export const useStore = create<State>((set, get) => ({
           const dragged = source ? findLeaf(source.layout, dragId) : undefined;
           if (!source || !target || !dragged) return n;
           const without = removeLeaf(source.layout, dragId);
-          const neighbor = nextFocusAfterClose(source.layout, dragId);
           return {
             ...n,
             activeHTab: targetHTabId,
@@ -1712,22 +1747,23 @@ export const useStore = create<State>((set, get) => ({
               if (h.id === source.id) {
                 if (!without) {
                   const replacement = makeLeaf();
-                  return { ...h, layout: replacement, focused: replacement.id, maximized: undefined };
+                  return {
+                    ...h,
+                    layout: replacement,
+                    focused: replacement.id,
+                    focusHistory: undefined,
+                    maximized: undefined,
+                  };
                 }
-                return {
-                  ...h,
-                  layout: without,
-                  focused: h.focused === dragId ? (neighbor ?? firstLeaf(without)) : h.focused,
-                  maximized: h.maximized === dragId ? undefined : h.maximized,
-                };
+                return tabAfterPaneRemoval(h, dragId, without);
               }
               if (h.id === target.id) {
-                return {
+                const next = {
                   ...h,
                   layout: tileLayout(h.layout, dragged),
-                  focused: dragged.id,
                   maximized: undefined,
                 };
+                return withFocusedPane(next, dragged.id);
               }
               return h;
             }),
@@ -1746,7 +1782,6 @@ export const useStore = create<State>((set, get) => ({
           if (!source || !dragged) return n;
           const without = removeLeaf(source.layout, dragId);
           if (!without) return n; // last pane of the tab — nothing to detach
-          const neighbor = nextFocusAfterClose(source.layout, dragId);
           const created: HTab = {
             id: id(),
             title: dragged.title,
@@ -1758,14 +1793,7 @@ export const useStore = create<State>((set, get) => ({
             activeHTab: created.id,
             htabs: [
               ...n.htabs.map((h) =>
-                h.id === source.id
-                  ? {
-                      ...h,
-                      layout: without,
-                      focused: h.focused === dragId ? (neighbor ?? firstLeaf(without)) : h.focused,
-                      maximized: h.maximized === dragId ? undefined : h.maximized,
-                    }
-                  : h
+                h.id === source.id ? tabAfterPaneRemoval(h, dragId, without) : h
               ),
               created,
             ],
@@ -1786,7 +1814,6 @@ export const useStore = create<State>((set, get) => ({
         if (!from || !source || !dragged || !findNode(ws.roots, toNodeId)) return ws;
         const without = removeLeaf(source.layout, dragId);
         if (!without) return ws; // last pane of the tab — nothing to detach
-        const neighbor = nextFocusAfterClose(source.layout, dragId);
         const created: HTab = {
           id: id(),
           title: dragged.title,
@@ -1797,12 +1824,7 @@ export const useStore = create<State>((set, get) => ({
           ...n,
           htabs: n.htabs.map((h) =>
             h.id === source.id
-              ? {
-                  ...h,
-                  layout: without,
-                  focused: h.focused === dragId ? (neighbor ?? firstLeaf(without)) : h.focused,
-                  maximized: h.maximized === dragId ? undefined : h.maximized,
-                }
+              ? tabAfterPaneRemoval(h, dragId, without)
               : h
           ),
         }));

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -2026,7 +2026,7 @@ html.tauri #root {
 /* Draw the focus ring as a top-most overlay so it sits ABOVE the opaque header
    (an inset box-shadow gets painted over by the header's background). It lands
    exactly on the card's own 1px border, recolouring the whole outline. */
-.pane-slot.focused::after {
+.pane-slot.focused.show-focus-ring::after {
   content: "";
   position: absolute;
   inset: 0;

--- a/apps/web/src/terminal/focusHandoff.test.ts
+++ b/apps/web/src/terminal/focusHandoff.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  reconcileAttachedTerminalFocus,
+  type FocusFrameScheduler,
+} from "./focusHandoff";
+
+function controlledFrames() {
+  let pending: (() => void) | undefined;
+  let cancelled: number | undefined;
+  const frames: FocusFrameScheduler = {
+    request: (callback) => {
+      pending = callback;
+      return 17;
+    },
+    cancel: (handle) => {
+      cancelled = handle;
+    },
+  };
+  return {
+    frames,
+    run: () => pending?.(),
+    cancelled: () => cancelled,
+  };
+}
+
+describe("reconcileAttachedTerminalFocus", () => {
+  it("focuses the canonical pane immediately and once more after layout", () => {
+    const scheduled = controlledFrames();
+    const reconciled: string[] = [];
+
+    reconcileAttachedTerminalFocus(
+      "new-pane",
+      () => "new-pane",
+      (paneId) => reconciled.push(paneId),
+      scheduled.frames,
+    );
+    scheduled.run();
+
+    assert.deepEqual(reconciled, ["new-pane", "new-pane"]);
+  });
+
+  it("never lets an unfocused attachment steal the keyboard", () => {
+    const scheduled = controlledFrames();
+    const reconciled: string[] = [];
+
+    reconcileAttachedTerminalFocus(
+      "old-pane",
+      () => "new-pane",
+      (paneId) => reconciled.push(paneId),
+      scheduled.frames,
+    );
+    scheduled.run();
+
+    assert.deepEqual(reconciled, []);
+  });
+
+  it("rechecks canonical focus instead of replaying a stale mount decision", () => {
+    const scheduled = controlledFrames();
+    const reconciled: string[] = [];
+    let focused = "new-pane";
+
+    reconcileAttachedTerminalFocus(
+      "new-pane",
+      () => focused,
+      (paneId) => reconciled.push(paneId),
+      scheduled.frames,
+    );
+    focused = "other-pane";
+    scheduled.run();
+
+    assert.deepEqual(reconciled, ["new-pane"]);
+  });
+
+  it("cancels the delayed recheck when the terminal detaches", () => {
+    const scheduled = controlledFrames();
+    const cancel = reconcileAttachedTerminalFocus(
+      "new-pane",
+      () => "new-pane",
+      () => {},
+      scheduled.frames,
+    );
+
+    cancel();
+
+    assert.equal(scheduled.cancelled(), 17);
+  });
+});

--- a/apps/web/src/terminal/focusHandoff.ts
+++ b/apps/web/src/terminal/focusHandoff.ts
@@ -1,0 +1,30 @@
+export interface FocusFrameScheduler {
+  request: (callback: () => void) => number;
+  cancel: (handle: number) => void;
+}
+
+const browserFrames: FocusFrameScheduler = {
+  request: (callback) => requestAnimationFrame(callback),
+  cancel: (handle) => cancelAnimationFrame(handle),
+};
+
+/**
+ * Reconcile a terminal when its DOM becomes attach-ready, then recheck after
+ * layout and the browser's default focus handling settle. Both passes read the
+ * canonical pane id at execution time, so a stale mount can never steal focus
+ * back from a pane the user selected in the meantime.
+ */
+export function reconcileAttachedTerminalFocus(
+  paneId: string,
+  focusedPaneId: () => string | undefined,
+  reconcile: (paneId: string) => void,
+  frames: FocusFrameScheduler = browserFrames,
+): () => void {
+  const focusIfStillCanonical = () => {
+    if (focusedPaneId() === paneId) reconcile(paneId);
+  };
+
+  focusIfStillCanonical();
+  const frame = frames.request(focusIfStillCanonical);
+  return () => frames.cancel(frame);
+}

--- a/apps/web/src/terminal/manager.ts
+++ b/apps/web/src/terminal/manager.ts
@@ -1077,6 +1077,59 @@ let currentTermTheme: ITheme = {
   selectionBackground: "#2a3441",
 };
 
+const HIDDEN_CURSOR = "rgba(0, 0, 0, 0)";
+
+function inactiveTermTheme(): ITheme {
+  return {
+    ...currentTermTheme,
+    cursor: HIDDEN_CURSOR,
+    cursorAccent: HIDDEN_CURSOR,
+  };
+}
+
+/**
+ * Project canonical pane focus into xterm's renderer rather than asking the
+ * renderer to infer it from WebKit's focus events. A transparent bar avoids
+ * WebGL's block-cursor cell colour override, so it is invisible even if
+ * xterm's private browser-focus flag is stale.
+ */
+function setSessionCursorFocused(
+  session: Session,
+  focused: boolean,
+  forceTheme = false,
+): boolean {
+  let changed = false;
+  if (focused) {
+    if (forceTheme || session.term.options.theme !== currentTermTheme) {
+      session.term.options.theme = currentTermTheme;
+      changed = true;
+    }
+    if (session.term.options.cursorStyle !== "block") {
+      session.term.options.cursorStyle = "block";
+      changed = true;
+    }
+    if (!session.term.options.cursorBlink) {
+      session.term.options.cursorBlink = true;
+      changed = true;
+    }
+    return changed;
+  }
+  const theme = session.term.options.theme;
+  if (forceTheme || theme?.cursor !== HIDDEN_CURSOR || theme?.cursorAccent !== HIDDEN_CURSOR) {
+    session.term.options.theme = inactiveTermTheme();
+    changed = true;
+  }
+  if (session.term.options.cursorStyle !== "bar") {
+    session.term.options.cursorStyle = "bar";
+    changed = true;
+  }
+  if (session.term.options.cursorBlink) {
+    session.term.options.cursorBlink = false;
+    changed = true;
+  }
+  return changed;
+}
+
 /** User-configured font, loaded once at startup and updated from Settings.
  *  Every new session starts with these; applyFontFamily / applyFontSize
  *  push changes to all live sessions immediately. */
@@ -1237,7 +1290,10 @@ function traceImeEvents(term: Terminal) {
 /** Switch the terminal palette: future sessions + all currently open ones. */
 export function applyTermTheme(theme: ITheme) {
   currentTermTheme = theme;
-  for (const s of sessions.values()) s.term.options.theme = theme;
+  for (const s of sessions.values()) {
+    const focused = s.el.closest(".pane-slot")?.classList.contains("focused") ?? false;
+    setSessionCursorFocused(s, focused, true);
+  }
 }
 
 // The bundled "Symbols Nerd Font Mono" (@font-face in styles.css) loads
@@ -1286,12 +1342,21 @@ function getSession(id: string, cwdFrom?: string[], sshTarget?: string, paneId =
     fontFamily: withSymbolsFallback(currentFontFamily),
     fontSize: currentFontSize,
     scrollback: SCROLLBACK_LINES,
-    cursorBlink: true,
+    // Sessions start visually inactive. The canonical focus reconciler turns
+    // exactly one into a blinking block after it has been attached.
+    cursorBlink: false,
+    cursorStyle: "bar",
+    // xterm's default inactive cursor is a full-strength outline in the same
+    // accent colour. That makes a correctly blurred pane still look focused,
+    // especially immediately after splitting. The pane ring/header retain the
+    // remembered focus cue; only the terminal that owns keyboard input draws
+    // a cursor.
+    cursorInactiveStyle: "none",
     allowProposedApi: true,
     // Lets art-forward themes use an rgba() terminal background so the window
     // artwork shows through the pane veil; opaque themes render identically.
     allowTransparency: true,
-    theme: currentTermTheme,
+    theme: inactiveTermTheme(),
   });
 
   const fit = new FitAddon();
@@ -1729,12 +1794,10 @@ function fixAbandonedImeFinalize(term: Terminal) {
 /**
  * Attach the session's element into `host` and open the terminal (once).
  *
- * `focus` must say whether this pane is the focused one. Removing a pane
- * collapses its parent split, which changes the React key of every surviving
- * pane in it and remounts them all; taking the keyboard unconditionally here
- * handed it to whichever pane happened to mount LAST while the focus ring
- * stayed on the pane the store had focused. Ring and keyboard then disagreed
- * until the next click.
+ * Attaching deliberately does NOT focus. A tab switch or split collapse mounts
+ * several sessions at once, and mount order must never decide which one owns
+ * the keyboard. React reconciles the one canonical store focus after attach
+ * and at the SplitView level instead.
  */
 export function attachSession(
   id: string,
@@ -1742,7 +1805,6 @@ export function attachSession(
   cwdFrom?: string[],
   sshTarget?: string,
   paneId = id,
-  focus = true
 ) {
   activeSessionByPane.set(paneId, id);
   let owned = sessionIdsByPane.get(paneId);
@@ -1790,7 +1852,6 @@ export function attachSession(
     s.opened = true;
   }
   fitSession(id);
-  if (focus) focusSession(id);
   const queued = pendingCommands.get(paneId) ?? pendingCommands.get(id);
   if (queued?.length) {
     pendingCommands.delete(paneId);
@@ -1847,7 +1908,61 @@ export function focusSession(id: string) {
   // In the landing-page demo iframe, programmatic focus on load would steal
   // the visitor's keyboard/scroll — hold off until they click into the demo.
   if (isDemo && !demoInteracted()) return;
-  sessions.get(id)?.term.focus();
+  const session = sessions.get(id);
+  if (!session) return;
+  setSessionCursorFocused(session, true);
+  session.term.focus();
+}
+
+function refreshSessionAfterLayout(id: string, expected: Session) {
+  // A split changes the old pane's dimensions in the same commit that moves
+  // focus to the new pane. WKWebView can coalesce xterm's blur repaint with
+  // the ResizeObserver-driven fit and leave the old WebGL cursor pixels on the
+  // canvas even though its textarea is correctly blurred. Wait until layout
+  // and the queued fit have both had a frame, then redraw from current focus
+  // state. Checking identity keeps a delayed callback away from disposed or
+  // replacement sessions.
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      const latest = sessions.get(id);
+      if (latest !== expected || !latest.opened) return;
+      latest.term.refresh(0, latest.term.rows - 1);
+    });
+  });
+}
+
+function blurRuntimeSession(id: string, session: Session) {
+  const hadDomFocus = session.term.element?.classList.contains("focus") ?? false;
+  const cursorChanged = setSessionCursorFocused(session, false);
+  session.term.blur();
+  if (!session.opened || (!hadDomFocus && !cursorChanged)) return;
+  session.term.refresh(0, session.term.rows - 1);
+  refreshSessionAfterLayout(id, session);
+}
+
+/** Immediately remove keyboard focus, then clear any post-resize cursor pixels. */
+export function blurSession(id: string) {
+  id = activeSessionId(id);
+  const session = sessions.get(id);
+  if (session) blurRuntimeSession(id, session);
+}
+
+/**
+ * Reconcile xterm's imperative DOM focus from the one canonical pane id.
+ *
+ * Splitting mounts the new terminal and updates the old PaneSlot in the same
+ * React commit. Independent pane effects have no useful ordering guarantee;
+ * focusing the new textarea before blurring the old one can make WebKit move
+ * `document.activeElement` without giving xterm's old WebGL renderer the blur
+ * transition that stops its cursor. A single coordinator makes the ordering
+ * explicit and also clears a terminal left focused in a background tab.
+ */
+export function reconcileTerminalFocus(focusedPaneId?: string) {
+  const focusedSessionId = focusedPaneId ? activeSessionId(focusedPaneId) : undefined;
+  for (const [id, session] of sessions) {
+    if (id !== focusedSessionId) blurRuntimeSession(id, session);
+  }
+  if (focusedSessionId) focusSession(focusedSessionId);
 }
 
 /**

--- a/apps/web/tests/paneFocus.test.ts
+++ b/apps/web/tests/paneFocus.test.ts
@@ -1,49 +1,119 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { nextFocusAfterClose } from "../src/state/paneFocus";
-import type { Pane } from "../src/state/store";
+import {
+  focusPane,
+  focusPaneAfterRemoval,
+  selectHTab,
+  type PaneFocusState,
+} from "../src/state/paneFocus";
 
-const leaf = (id: string): Pane => ({ kind: "leaf", id, title: id });
-const row = (...children: Pane[]): Pane => ({ kind: "split", dir: "row", children });
-const col = (...children: Pane[]): Pane => ({ kind: "split", dir: "col", children });
+const panes = ["a", "b", "c"];
 
-describe("nextFocusAfterClose", () => {
-  it("hands focus to the pane after the closed one", () => {
-    assert.equal(nextFocusAfterClose(row(leaf("a"), leaf("b"), leaf("c")), "b"), "c");
+describe("focusPane", () => {
+  it("records the previously focused pane as the most recent fallback", () => {
+    const first = focusPane({ focused: "a" }, "b", panes);
+    const second = focusPane(first, "c", panes);
+
+    assert.deepEqual(second, {
+      focused: "c",
+      focusHistory: ["b", "a"],
+    });
   });
 
-  it("falls back to the pane before it when the closed pane was last", () => {
-    assert.equal(nextFocusAfterClose(row(leaf("a"), leaf("b"), leaf("c")), "c"), "b");
+  it("moves a revisited pane to the front without duplicating it", () => {
+    const state: PaneFocusState = {
+      focused: "c",
+      focusHistory: ["b", "a"],
+    };
+
+    assert.deepEqual(focusPane(state, "a", panes), {
+      focused: "a",
+      focusHistory: ["c", "b"],
+    });
   });
 
-  it("stays inside the split that held the closed pane", () => {
-    // row[ a , col[b, c] ] — closing c must land on b, its own sibling, and
-    // not jump across the tab to a.
-    assert.equal(nextFocusAfterClose(row(leaf("a"), col(leaf("b"), leaf("c"))), "c"), "b");
+  it("ignores a pane that does not belong to this tab", () => {
+    const state: PaneFocusState = { focused: "a" };
+    assert.equal(focusPane(state, "outside", panes), state);
   });
 
-  it("picks the nearest edge of a neighbouring subtree, not its first leaf", () => {
-    // row[ col[a, b] , c ] — closing c grows the left column, whose visually
-    // nearest pane is b (its bottom), not a.
-    assert.equal(nextFocusAfterClose(row(col(leaf("a"), leaf("b")), leaf("c")), "c"), "b");
+  it("does not create a second focus state when focus is unchanged", () => {
+    const state: PaneFocusState = { focused: "a" };
+    assert.equal(focusPane(state, "a", panes), state);
+  });
+});
+
+describe("focusPaneAfterRemoval", () => {
+  it("restores the previously focused pane instead of the spatial neighbour", () => {
+    // Layout order is a, b, c. The old neighbour rule chose b after closing c,
+    // but the user's actual focus order was b -> a -> c, so a must come back.
+    const state: PaneFocusState = {
+      focused: "c",
+      focusHistory: ["a", "b"],
+    };
+
+    assert.deepEqual(focusPaneAfterRemoval(state, "c", ["a", "b"]), {
+      focused: "a",
+      focusHistory: ["b"],
+    });
   });
 
-  it("enters the next subtree at its first leaf", () => {
-    assert.equal(nextFocusAfterClose(row(leaf("a"), col(leaf("b"), leaf("c"))), "a"), "b");
+  it("keeps current focus when an unfocused pane closes and prunes its history", () => {
+    const state: PaneFocusState = {
+      focused: "c",
+      focusHistory: ["b", "a"],
+    };
+
+    assert.deepEqual(focusPaneAfterRemoval(state, "b", ["a", "c"]), {
+      focused: "c",
+      focusHistory: ["a"],
+    });
   });
 
-  it("never returns the pane being closed", () => {
-    const layout = row(leaf("a"), col(leaf("b"), leaf("c")), leaf("d"));
-    for (const id of ["a", "b", "c", "d"]) {
-      assert.notEqual(nextFocusAfterClose(layout, id), id);
-    }
+  it("skips stale history entries and falls back deterministically", () => {
+    const state: PaneFocusState = {
+      focused: "c",
+      focusHistory: ["gone"],
+    };
+
+    assert.deepEqual(focusPaneAfterRemoval(state, "c", ["a", "b"]), {
+      focused: "a",
+    });
   });
 
-  it("returns null when the closed pane was the only one", () => {
-    assert.equal(nextFocusAfterClose(leaf("a"), "a"), null);
+  it("repairs a stale focused id using a surviving history entry", () => {
+    const state: PaneFocusState = {
+      focused: "gone",
+      focusHistory: ["b", "a"],
+    };
+
+    assert.deepEqual(focusPaneAfterRemoval(state, "c", ["a", "b"]), {
+      focused: "b",
+      focusHistory: ["a"],
+    });
+  });
+});
+
+describe("selectHTab", () => {
+  it("preserves each tab's focused pane and history while switching", () => {
+    const tabs = [
+      { id: "tab-a", focused: "a", focusHistory: ["b"] },
+      { id: "tab-b", focused: "c", focusHistory: ["d"] },
+    ];
+    const state = { activeHTab: "tab-a", htabs: tabs };
+
+    const switched = selectHTab(state, "tab-b");
+
+    assert.equal(switched.activeHTab, "tab-b");
+    assert.equal(switched.htabs, tabs);
+    assert.deepEqual(switched.htabs, [
+      { id: "tab-a", focused: "a", focusHistory: ["b"] },
+      { id: "tab-b", focused: "c", focusHistory: ["d"] },
+    ]);
   });
 
-  it("returns null for a pane that is not in the layout", () => {
-    assert.equal(nextFocusAfterClose(row(leaf("a"), leaf("b")), "zzz"), null);
+  it("ignores an unknown tab instead of losing the active focus", () => {
+    const state = { activeHTab: "tab-a", htabs: [{ id: "tab-a", focused: "a" }] };
+    assert.equal(selectHTab(state, "missing"), state);
   });
 });


### PR DESCRIPTION
## 起因

Pane 的选中状态、DOM/xterm 实际焦点和光标渲染之前由不同路径分别维护。创建 split 时，terminal 的挂载顺序和异步回调可能独立抢占焦点，导致高亮框、键盘输入目标和 WebGL 光标落在不同 pane 上。切换 tab 时焦点也可能被重新计算；关闭 pane 时则会选择空间上相邻的 pane，而不是用户上一次实际聚焦的 pane。

## 解决方式

- 以 `HTab.focused` 作为当前 pane 焦点的唯一 canonical 状态；`focusHistory` 只保存此前 pane 的 MRU 顺序。
- 创建、选择、切换 tab、拖动、最大化和关闭 pane 全部通过同一组 focus reducer 更新状态。
- 集中协调 terminal 焦点：先让所有非目标 session 失焦，再把焦点交给 canonical 目标。
- terminal attach 完成后立即、并在下一帧重新执行焦点协调；每次都重新读取 canonical 状态，避免旧的挂载流程异步抢回焦点。
- 根据 canonical 焦点直接投影 xterm 光标状态；非焦点 pane 使用透明的 inactive cursor，并在 WKWebView/WebGL resize 后补充重绘。
- 为 Agent 和原生 webview 的异步 focus 增加 canonical 状态保护，后台 pane 不再抢占键盘。

## 当前效果

- 使用快捷键或 pane rail 创建新 pane 后，新 pane 会立即获得键盘焦点。
- 原 pane 会失去活动光标，不再继续闪烁。
- 切换 tab 会保持每个 tab 自己的焦点位置。
- 关闭当前 pane 后会恢复最近实际聚焦且仍存活的 pane，而不是简单选择邻近 pane。
- 高亮框、键盘输入目标和可见光标由同一份状态驱动，保持一致。

## 验证

- `npm -w @termany/web test`：155/155 通过
- `npm -w @termany/web run build`：通过
- 隔离的 macOS Tauri debug app 验收：
  - 按 `Command+Shift+D` 创建 pane 后立即输入唯一探针文本，文本只进入新 pane
  - 通过 pane rail 创建 pane 时，新 pane 同样获得输入焦点
  - 跨多个 blink 周期采样，旧 pane 没有残留闪烁光标
  - 鼠标/快捷键切换 pane、tab 往返切换和 MRU 关闭行为均保持一致
