### PR TITLE
fix(server): stop a stray git spawn rejection from killing every terminal session

### DIFF
--- a/apps/server/src/git.ts
+++ b/apps/server/src/git.ts
@@ -198,12 +198,19 @@ function defaultBase(wt: Omit<GitWorktree, "files">, refs: string[], mainBranch:
  */
 async function changedCount(root: string, base: string | undefined): Promise<number> {
   try {
-    const status = git(["status", "--porcelain=v1", "-z"], root);
-    const tracked = base
-      ? git(["diff", "--name-only", "-z", await mergeBase(root, base)], root)
-      : Promise.resolve("");
-    const files = new Set((await tracked).split("\0").filter(Boolean));
-    const records = (await status).split("\0");
+    // Promise.all observes BOTH promises even when one rejects — awaiting them
+    // sequentially let the first rejection skip the second await, stranding an
+    // unhandled rejection that takes the whole server down (spawn git ENOENT
+    // when the worktree directory was deleted behind our back, or git itself
+    // is missing from the server's PATH).
+    const [statusOut, trackedOut] = await Promise.all([
+      git(["status", "--porcelain=v1", "-z"], root),
+      base
+        ? mergeBase(root, base).then((mb) => git(["diff", "--name-only", "-z", mb], root))
+        : Promise.resolve(""),
+    ]);
+    const files = new Set(trackedOut.split("\0").filter(Boolean));
+    const records = statusOut.split("\0");
     for (let i = 0; i < records.length; i++) {
       const record = records[i];
       if (record.length < 4) continue;


### PR DESCRIPTION
## Problem

On Windows, switching or creating a tab killed every running agent (Kimi Code,
Codex, etc.) in all panes. The pane then showed
`[session ended — starting a new shell]` followed by
`[session ended: unable to connect to Termany PTY server at localhost:5174]`,
and came back as a plain shell after the desktop watchdog restarted the server.

## Root cause

`server.log` showed the PTY server crashing repeatedly with
`Error: spawn git ENOENT`.

Switching/creating a tab refreshes the git panel (`GET /api/git/overview`).
For repos with multiple worktrees (agents create these), `changedCount()` runs
`git status` inside each worktree directory. When an agent had deleted its
worktree behind the server's back, spawning git in that missing cwd failed with
ENOENT.

`changedCount()` created two promises and awaited them sequentially. The first
awaited rejection was swallowed by the surrounding try/catch, but the second
promise's rejection was never observed → unhandled rejection → Node exits the
process. Every PTY (and every agent) died with it; the watchdog then restarted
the server, which is why panes came back as fresh shells.

## Fix

Await both promises together with `Promise.all`, so a rejection on either side
can never strand the other as an unhandled rejection.

## Verification

- Repro (multi-worktree repo, delete one worktree directory, then call
  `gitOverview`): old code reliably produced
  `UNHANDLED REJECTION: spawn git ENOENT`; fixed code resolves cleanly.
- Existing server test suite: 67 pass / 4 fail, identical before and after the
  change (the 4 failures are pre-existing Windows environment issues, unrelated
  to `git.ts`).
