### PR TITLE
fix(web): blank native preview panes behind modal dialogs

### DIFF
--- a/apps/web/src/components/AgentPane.tsx
+++ b/apps/web/src/components/AgentPane.tsx
@@ -6,6 +6,7 @@ import { agentModelSetup } from "../agentModelSetup";
 import { apiPath } from "../api";
 import { useI18n } from "../i18n";
 import { useImeGuard } from "../imeGuard";
+import { useNativeOccluder } from "../nativeViewOcclusion";
 import { cwdCandidates, useStore, type AgentMessage, type AgentPart, type Pane } from "../state/store";
 import { queueCommand } from "../terminal/manager";
 import { CheckIcon, ChevronIcon, CopyIcon, FolderIcon, SendIcon, SpinnerIcon, StopIcon, TerminalIcon } from "./icons";
@@ -178,6 +179,7 @@ export function AgentPane({ leaf }: { leaf: Leaf }) {
   const [acpConfig, setAcpConfig] = useState<AcpConfigOption[] | null>(null);
   const [acpConfigBusy, setAcpConfigBusy] = useState(false);
   const [modelHelp, setModelHelp] = useState(false);
+  const modelHelpBackdropRef = useNativeOccluder<HTMLDivElement>("agent-models-help", modelHelp);
   const abortRef = useRef<AbortController | null>(null);
   const streamingRef = useRef(false);
   const ime = useImeGuard();
@@ -703,6 +705,7 @@ export function AgentPane({ leaf }: { leaf: Leaf }) {
         createPortal(
           <div
             className="ws-dialog-backdrop"
+            ref={modelHelpBackdropRef}
             onMouseDown={(event) => {
               if (event.target === event.currentTarget) setModelHelp(false);
             }}

--- a/apps/web/src/components/QuitConfirm.tsx
+++ b/apps/web/src/components/QuitConfirm.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { isTauri } from "../env";
+import { useNativeOccluder } from "../nativeViewOcclusion";
 
 /**
  * Confirms before the app actually quits. The Rust side always intercepts
@@ -12,6 +13,7 @@ import { isTauri } from "../env";
  */
 export function QuitConfirm() {
   const [open, setOpen] = useState(false);
+  const backdropRef = useNativeOccluder<HTMLDivElement>("quit-confirm", open);
 
   useEffect(() => {
     if (!isTauri) return;
@@ -45,7 +47,7 @@ export function QuitConfirm() {
   };
 
   return (
-    <div className="ws-dialog-backdrop" onClick={() => setOpen(false)}>
+    <div className="ws-dialog-backdrop" ref={backdropRef} onClick={() => setOpen(false)}>
       <div className="ws-dialog" onClick={(e) => e.stopPropagation()}>
         <p className="quit-confirm-text">Quit Termany? All open tabs and panes will close.</p>
         <div className="ws-dialog-actions">

--- a/apps/web/src/components/SystemMonitor.tsx
+++ b/apps/web/src/components/SystemMonitor.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { apiPath } from "../api";
 import { useI18n } from "../i18n";
+import { useNativeOccluder } from "../nativeViewOcclusion";
 import { ActivityIcon } from "./icons";
 
 type Translate = ReturnType<typeof useI18n>["t"];
@@ -218,6 +219,9 @@ export function SystemMonitor() {
   const [detail, setDetail] = useState<ProcessDetail | null>(null);
   const [detailHistory, setDetailHistory] = useState<{ cpu: number; mem: number }[]>([]);
   const [notice, setNotice] = useState<string | null>(null);
+  // Native web/office preview panes paint above the DOM and ignore z-index,
+  // so one overlapping this centered dialog would swallow the buttons' clicks.
+  const detailBackdropRef = useNativeOccluder<HTMLDivElement>("sysmon-process-detail", detail !== null);
 
   const openDetail = (d: ProcessDetail, group: boolean) => {
     setDetailId({ pid: d.pid, name: d.name, group });
@@ -513,7 +517,7 @@ export function SystemMonitor() {
       </div>
 
       {detail && (
-        <div className="ws-dialog-backdrop" onClick={closeDetail}>
+        <div className="ws-dialog-backdrop" ref={detailBackdropRef} onClick={closeDetail}>
           <div className="ws-dialog sysmon-detail" onClick={(e) => e.stopPropagation()}>
             <div className="sysmon-detail-head">
               <span className="sysmon-detail-icon" aria-hidden>

--- a/apps/web/src/components/WorkspaceDialog.tsx
+++ b/apps/web/src/components/WorkspaceDialog.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useI18n } from "../i18n";
 import { useImeGuard } from "../imeGuard";
+import { useNativeOccluder } from "../nativeViewOcclusion";
 import { EmojiPicker } from "./EmojiPicker";
 
 const initial = (t: string) => t.trim().charAt(0).toUpperCase() || "?";
@@ -27,13 +28,14 @@ export function WorkspaceDialog({
   const [icon, setIcon] = useState<string | undefined>(initIcon);
   const [pickerOpen, setPickerOpen] = useState(false);
   const ime = useImeGuard();
+  const backdropRef = useNativeOccluder<HTMLDivElement>("workspace-dialog");
 
   const submit = () => {
     if (title.trim()) onConfirm({ title: title.trim(), icon });
   };
 
   return (
-    <div className="ws-dialog-backdrop" onClick={onClose}>
+    <div className="ws-dialog-backdrop" ref={backdropRef} onClick={onClose}>
       <div className="ws-dialog" onClick={(e) => e.stopPropagation()}>
         <div className="ws-dialog-row">
           <button className="ws-dialog-icon" title={t("workspace.chooseIcon")} onClick={() => setPickerOpen((o) => !o)}>

--- a/apps/web/src/components/WorkspaceSwitcher.tsx
+++ b/apps/web/src/components/WorkspaceSwitcher.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useI18n } from "../i18n";
+import { useNativeOccluder } from "../nativeViewOcclusion";
 import { useStore } from "../state/store";
 import { titleBarBackground, useTitleBarGesture } from "../titleBar";
 import { EmojiPicker } from "./EmojiPicker";
@@ -31,6 +32,7 @@ export function WorkspaceSwitcher({ onOpenSettings }: { onOpenSettings: () => vo
   const [emojiOpen, setEmojiOpen] = useState(false);
   const [dialog, setDialog] = useState<DialogState | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<{ id: string; title: string } | null>(null);
+  const deleteBackdropRef = useNativeOccluder<HTMLDivElement>("workspace-delete", deleteTarget !== null);
 
   const active = workspaces.find((w) => w.id === activeId) ?? workspaces[0];
   // Doubles as the window's title bar on desktop, same as the tab strip: the
@@ -166,7 +168,7 @@ export function WorkspaceSwitcher({ onOpenSettings }: { onOpenSettings: () => vo
       )}
 
       {deleteTarget && (
-        <div className="ws-dialog-backdrop" onClick={() => setDeleteTarget(null)}>
+        <div className="ws-dialog-backdrop" ref={deleteBackdropRef} onClick={() => setDeleteTarget(null)}>
           <div className="ws-dialog" onClick={(e) => e.stopPropagation()}>
             <p className="quit-confirm-text">
               {t("workspace.deleteConfirm", { name: deleteTarget.title })}

--- a/apps/web/src/nativeViewOcclusion.ts
+++ b/apps/web/src/nativeViewOcclusion.ts
@@ -10,6 +10,8 @@
  * every web/office preview pane in the workspace.
  */
 
+import { useEffect, useRef } from "react";
+
 export interface OcclusionRect {
   x: number;
   y: number;
@@ -35,6 +37,30 @@ export function registerOccluder(id: string, rect: OcclusionRect) {
 export function unregisterOccluder(id: string) {
   if (!occluders.delete(id)) return;
   window.dispatchEvent(new Event(OCCLUSION_CHANGED_EVENT));
+}
+
+/**
+ * For modal dialogs: registers the referenced element (the backdrop, so the
+ * shaded region is what blanks native views) as an occluder while `active`,
+ * unregisters on close/unmount. Any dialog that can overlap a web/office
+ * preview pane needs this — without it the native view paints over the dialog
+ * and swallows its clicks, z-index notwithstanding.
+ */
+export function useNativeOccluder<T extends HTMLElement>(id: string, active = true) {
+  const ref = useRef<T>(null);
+  useEffect(() => {
+    const el = ref.current;
+    if (!active || !el) return;
+    const sync = () => registerOccluder(id, el.getBoundingClientRect());
+    const observer = new ResizeObserver(sync);
+    observer.observe(el);
+    sync();
+    return () => {
+      observer.disconnect();
+      unregisterOccluder(id);
+    };
+  }, [id, active]);
+  return ref;
 }
 
 function intersects(a: OcclusionRect, b: OcclusionRect): boolean {


### PR DESCRIPTION
## Problem

Web/office preview panes are native child webviews (WebView2 on Windows) that paint above the DOM and ignore z-index. A modal dialog overlapping one has its buttons swallowed by the native view — most visibly the system monitor's process detail dialog, where Close / Quit / Force Quit all appear dead on Windows when a preview pane sits underneath the centered dialog.

## Root cause

The app already solves this for menus (`PopMenu`, SideRail agent menu) and the SSH manager dialog by registering the popup's rect with `nativeViewOcclusion`, which blanks the overlapping native views while the popup is open. The `ws-dialog-backdrop` modals never opted in.

## Fix

Add a `useNativeOccluder(id, active)` hook in `nativeViewOcclusion.ts` packaging the register-on-open / unregister-on-close pattern (same logic `SshManagerDialog` inlines), and wire it into the five dialogs missing it:

- `SystemMonitor` process detail dialog
- `QuitConfirm`
- `WorkspaceDialog` (create/edit workspace)
- `WorkspaceSwitcher` delete confirmation
- `AgentPane` agent-models help

## Verification

Reproduced on Windows with the dev servers and a CDP-driven browser: in a plain browser all dialog buttons work (no native views there), confirming the issue is native-view occlusion in the desktop shell. After the fix, opening the process detail dialog fires the occlusion-changed event (occluder registered) and closing it unregisters. `tsc --noEmit` + `vite build` pass; web tests 149/149.