### PR TITLE
feat(server): expose the pane id to the shell as TERMANY_PANE_ID

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1872,7 +1872,7 @@ wss.on("connection", async (ws: WebSocket, req) => {
       cols: 80,
       rows: 24,
       cwd,
-      env: ptyEnvironment(),
+      env: ptyEnvironment(process.env, process.platform, sessionId ?? undefined),
     });
   } catch (err) {
     // Never let one bad spawn take down the whole server.

--- a/apps/server/src/ptyEnvironment.test.ts
+++ b/apps/server/src/ptyEnvironment.test.ts
@@ -30,6 +30,27 @@ test("replaces a non-UTF-8 LC_ALL without changing other locale categories", () 
   );
 });
 
+test("publishes the pane id so programs in the pane can identify it", () => {
+  assert.deepEqual(ptyEnvironment({ LANG: "en_US.UTF-8" }, "darwin", "pane-1"), {
+    LANG: "en_US.UTF-8",
+    TERM: "xterm-256color",
+    TERMANY_PANE_ID: "pane-1",
+  });
+});
+
+test("publishes the pane id on Windows too", () => {
+  assert.deepEqual(ptyEnvironment({ LANG: "C" }, "win32", "pane-1"), {
+    LANG: "C",
+    TERM: "xterm-256color",
+    TERMANY_PANE_ID: "pane-1",
+  });
+});
+
+test("omits the pane id for sessions that do not have one", () => {
+  const env = ptyEnvironment({ LANG: "en_US.UTF-8" }, "darwin");
+  assert.equal("TERMANY_PANE_ID" in env, false);
+});
+
 test("does not alter locale variables on Windows", () => {
   assert.deepEqual(ptyEnvironment({ LANG: "C" }, "win32"), {
     LANG: "C",

--- a/apps/server/src/ptyEnvironment.ts
+++ b/apps/server/src/ptyEnvironment.ts
@@ -9,12 +9,21 @@
  * Only the character classification locale is repaired. Other locale
  * categories keep the user's values, and an existing UTF-8 locale is left
  * untouched.
+ *
+ * `paneId` publishes the pane's session id as `TERMANY_PANE_ID`, so a program
+ * running inside the pane can tell which pane it is in. Terminals commonly
+ * expose such an identifier (`ITERM_SESSION_ID`, `WEZTERM_PANE`, `TMUX_PANE`),
+ * and tools that automate a specific pane need it: without one they have to
+ * guess from the working directory or scrape the scrollback, both of which
+ * pick the wrong pane when several sessions share a directory.
  */
 export function ptyEnvironment(
   source: NodeJS.ProcessEnv = process.env,
-  platform: NodeJS.Platform = process.platform
+  platform: NodeJS.Platform = process.platform,
+  paneId?: string
 ): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { ...source, TERM: "xterm-256color" };
+  if (paneId) env.TERMANY_PANE_ID = paneId;
   if (platform === "win32") return env;
 
   const effectiveCharacterLocale = env.LC_ALL || env.LC_CTYPE || env.LANG || "";


### PR DESCRIPTION
## Problem

A program running inside a pane has no way to tell which pane it is in.

Most terminals publish such an identifier — `ITERM_SESSION_ID`, `WEZTERM_PANE`,
`TMUX_PANE` — and tooling relies on it. In Termany there is currently nothing:
`ptyEnvironment()` sets only `TERM` and repairs the locale.

That matters for anything that automates one specific pane (send text to *this*
agent session, read *this* pane's output). Without an identifier the tool has to
infer the pane from the working directory or by scraping the scrollback. Both
pick the wrong pane as soon as two sessions share a directory — and writing to
the wrong pane means sending input into someone else's session.

## Change

The pane's session id is already in scope where the PTY is spawned, so this just
passes it through:

- `ptyEnvironment()` takes an optional `paneId` and sets `TERMANY_PANE_ID`.
- The spawn site passes the existing `sessionId`.

Ephemeral sessions (no `session` query param) have no id and are unchanged.
The locale repair logic is untouched. Windows gets the variable too, since the
value has nothing to do with locale handling.

## Verification

- `npm test` in `apps/server`: **81 passing, 0 failing** (3 new tests cover
  present / absent / Windows).
- Against a real server started from this branch: connecting to
  `ws://localhost:5199/?session=verify-a3f69682` and running
  `echo $TERMANY_PANE_ID` in the pane prints `verify-a3f69682`.

## Why upstream rather than a local patch

I am building tooling that drives agent sessions running inside Termany. It
works today by reverse-engineering the pane from `/api/state` and the scrollback,
which covers only part of the panes and is fragile. One environment variable
removes that guesswork for every such tool, not just mine.

Happy to adjust the variable name (`TERMANY_PANE`, `TERMANY_SESSION_ID`, …) or
gate it behind a setting if you would rather not add it unconditionally.
