### PR TITLE
feat(server): let a pane run a given command instead of an interactive shell

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -49,6 +49,7 @@ import { gitDiffs, gitOverview, worktreeOverview } from "./git.js";
 import { pickFolder } from "./folderPicker.js";
 import { testProvider } from "./providerTest.js";
 import { ptyEnvironment } from "./ptyEnvironment.js";
+import { shellArgsForCommand } from "./shellCommand.js";
 import { resolveExecutable } from "./shellPath.js";
 import { generateTheme } from "./theme.js";
 
@@ -212,6 +213,7 @@ const OSC7_PS_HOOK = [
 const SHELL_ARGS = IS_WIN
   ? ["-NoLogo", "-NoProfile", "-NoExit", "-Command", OSC7_PS_HOOK]
   : ["-l"];
+
 
 // Populated from the PTY's own output (Windows only — see OSC7_PS_HOOK above),
 // keyed by pid so cwdForPid() can serve it the same way it serves the native
@@ -1718,6 +1720,9 @@ wss.on("connection", async (ws: WebSocket, req) => {
   const sessionId = url.searchParams.get("session");
   const sshTarget = url.searchParams.get("ssh");
   const agent = url.searchParams.get("agent") ?? undefined;
+  // Run this instead of an interactive prompt. Ignored when reattaching (the
+  // shell is already running) and when `ssh` is set (the remote decides).
+  const command = url.searchParams.get("cmd") ?? "";
 
   // --- Reattach: the session's shell is still running (detached or stolen
   // from a stale connection) — resume it instead of spawning a fresh one.
@@ -1867,7 +1872,10 @@ wss.on("connection", async (ws: WebSocket, req) => {
 
   let pty: ReturnType<typeof spawn>;
   try {
-    pty = spawn(sshArgs ? "ssh" : SHELL, sshArgs ?? SHELL_ARGS, {
+    const shellArgs = command
+      ? shellArgsForCommand(command, process.platform, IS_WIN ? OSC7_PS_HOOK : "")
+      : SHELL_ARGS;
+    pty = spawn(sshArgs ? "ssh" : SHELL, sshArgs ?? shellArgs, {
       name: "xterm-256color",
       cols: 80,
       rows: 24,

--- a/apps/server/src/shellCommand.test.ts
+++ b/apps/server/src/shellCommand.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { shellArgsForCommand } from "./shellCommand.js";
+
+test("runs the command through a login shell so ~/.zprofile still applies", () => {
+  assert.deepEqual(shellArgsForCommand("my-cli --flag", "darwin"), [
+    "-l",
+    "-c",
+    "my-cli --flag",
+  ]);
+});
+
+test("stays non-interactive so ~/.zshrc aliases cannot rewrite the command", () => {
+  // `-c` is what makes it non-interactive, and that is the whole point: an
+  // interactive shell would source ~/.zshrc and a same-named alias or function
+  // would silently run something other than what the caller asked for.
+  const args = shellArgsForCommand("codex --some-flag", "linux");
+  assert.ok(args.includes("-c"), "must pass -c");
+  assert.ok(!args.includes("-i"), "must never be interactive");
+});
+
+test("does not mangle quotes or spaces in the command", () => {
+  const command = `sh -c 'echo "hello world"'`;
+  assert.equal(shellArgsForCommand(command, "darwin").at(-1), command);
+});
+
+test("windows runs the command after the prompt hook", () => {
+  const args = shellArgsForCommand("my-cli", "win32", "function prompt { }");
+  assert.deepEqual(args.slice(0, 3), ["-NoLogo", "-NoProfile", "-Command"]);
+  assert.equal(args.at(-1), "function prompt { }\nmy-cli");
+});
+
+test("windows omits -NoExit so the pane closes when the command finishes", () => {
+  // The interactive path uses -NoExit to keep the prompt alive; a pane created
+  // to run one command should end with it rather than linger as a dead shell.
+  assert.ok(!shellArgsForCommand("my-cli", "win32").includes("-NoExit"));
+});
+
+test("windows without a prompt hook runs the bare command", () => {
+  assert.equal(shellArgsForCommand("my-cli", "win32").at(-1), "my-cli");
+});

--- a/apps/server/src/shellCommand.ts
+++ b/apps/server/src/shellCommand.ts
@@ -1,0 +1,26 @@
+/**
+ * Shell arguments for a pane that should run a specific command instead of
+ * dropping the user at an interactive prompt.
+ *
+ * The important difference from the interactive path is what gets sourced.
+ * On POSIX, `-l -c` is a LOGIN but NON-interactive shell: it still runs
+ * ~/.zprofile (PATH, Homebrew, fnm, pyenv, …) so the command resolves the same
+ * way it would in the user's terminal, but it skips ~/.zshrc.
+ *
+ * Skipping ~/.zshrc is the point, not an accident. That file is where aliases
+ * and shell functions live, so an interactive pane running `foo` may really be
+ * running the user's wrapper around `foo`. A caller that asks for a specific
+ * command wants that command. (The interactive path keeps ~/.zshrc precisely
+ * because a human at a prompt does want their aliases.)
+ */
+export function shellArgsForCommand(
+  command: string,
+  platform: NodeJS.Platform = process.platform,
+  windowsPromptHook = "",
+): string[] {
+  if (platform === "win32") {
+    const script = windowsPromptHook ? `${windowsPromptHook}\n${command}` : command;
+    return ["-NoLogo", "-NoProfile", "-Command", script];
+  }
+  return ["-l", "-c", command];
+}


### PR DESCRIPTION
### What

Adds an optional `cmd` query parameter to the PTY WebSocket. When present, the pane runs that command instead of dropping the user at an interactive prompt.

```
ws://localhost:5174/?session=<id>&cmd=<command line>
```

### Why a parameter instead of just typing the command in

The two paths don't source the same files. `node-pty` hands the shell a tty, so today's pane is a login **and** interactive shell — which means it reads `~/.zshrc`, and that's where aliases and shell functions live. Typing `foo` into it can silently run the user's wrapper around `foo` rather than `foo` itself. That's exactly right for a human at a prompt, and wrong for a caller that asked for a specific command.

`-l -c` keeps the login half — `~/.zprofile` still sets up PATH, Homebrew, fnm, pyenv — and drops the interactive half, so the command runs as written.

Typing is also racy for anything automated: the caller has to guess when the prompt is ready, and the newline must be a separate write or line editors treat the whole thing as a paste.

### Verification

Against a fixture whose `~/.zshrc` aliases the command name to something else, with the real binary on a PATH set by `~/.zprofile`:

| path | result |
|---|---|
| interactive shell + typed command | runs the **alias** |
| `?cmd=` | runs the **real binary**, and `~/.zprofile`'s PATH is still in effect |

`npm -w @termany/server run test` — 84 pass (6 new).

### Notes

- **No new capability.** A client that can open this socket can already write arbitrary input into a shell.
- `cmd` is ignored when reattaching to a live session, and when `ssh` is set (the remote decides).
- Windows omits `-NoExit`, so a pane created to run one command ends with it instead of lingering as a dead shell.
- Logic lives in `shellCommand.ts` with unit tests, following the existing `ptyEnvironment.ts` shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)