### PR TITLE
fix(server): read a pane's working directory when its path is not ASCII

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -48,6 +48,7 @@ import {
 import { gitDiffs, gitOverview, worktreeOverview } from "./git.js";
 import { pickFolder } from "./folderPicker.js";
 import { testProvider } from "./providerTest.js";
+import { cwdForPid as nativeCwdForPid } from "./processCwd.js";
 import { ptyEnvironment } from "./ptyEnvironment.js";
 import { resolveExecutable } from "./shellPath.js";
 import { generateTheme } from "./theme.js";
@@ -1522,22 +1523,9 @@ const wss = new WebSocketServer({ server: http });
 let connCount = 0;
 
 async function cwdForPid(pid: number): Promise<string | undefined> {
-  try {
-    if (os.platform() === "linux") return await fs.promises.realpath(`/proc/${pid}/cwd`);
-    if (os.platform() === "darwin") {
-      const { stdout } = await execFileAsync("lsof", ["-a", "-d", "cwd", "-p", String(pid), "-Fn"], {
-        timeout: 1000,
-        maxBuffer: 4096,
-      });
-      const line = stdout
-        .split("\n")
-        .find((value) => value.startsWith("n") && value.length > 1);
-      return line?.slice(1);
-    }
-  } catch {
-    return undefined;
-  }
-  return oscCwdByPid.get(pid);
+  // Windows has neither /proc nor lsof, so nativeCwdForPid declines and the
+  // PTY's own OSC 7 reports (see OSC7_PS_HOOK above) are all there is.
+  return (await nativeCwdForPid(pid)) ?? oscCwdByPid.get(pid);
 }
 
 /**

--- a/apps/server/src/processCwd.test.ts
+++ b/apps/server/src/processCwd.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { cwdForPid, lsofEnvironment } from "./processCwd.js";
+
+test("asks lsof for UTF-8 output", () => {
+  assert.equal(lsofEnvironment({}).LC_CTYPE, "UTF-8");
+});
+
+test("drops an inherited LC_ALL, which would outrank LC_CTYPE", () => {
+  // Overriding LC_CTYPE alone is not enough: LC_ALL wins, so lsof would keep
+  // escaping non-ASCII paths and the fix would look applied but do nothing.
+  const env = lsofEnvironment({ LC_ALL: "C", LANG: "C", PATH: "/usr/bin" });
+  assert.ok(!("LC_ALL" in env), "LC_ALL must be removed, not overridden");
+  assert.equal(env.LC_CTYPE, "UTF-8");
+});
+
+test("leaves the rest of the environment alone", () => {
+  const env = lsofEnvironment({ PATH: "/usr/bin", LANG: "de_DE.UTF-8" });
+  assert.equal(env.PATH, "/usr/bin");
+  assert.equal(env.LANG, "de_DE.UTF-8"); // outranked by LC_CTYPE, so harmless
+});
+
+test("does not mutate the environment it was given", () => {
+  const original: NodeJS.ProcessEnv = { LC_ALL: "C" };
+  lsofEnvironment(original);
+  assert.equal(original.LC_ALL, "C");
+});
+
+test(
+  "reads a non-ASCII working directory from a live process",
+  { skip: process.platform === "win32" ? "POSIX only" : false },
+  async () => {
+    const base = await fs.promises.mkdtemp(path.join(os.tmpdir(), "termany-cwd-"));
+    const dir = path.join(base, "代码");
+    await fs.promises.mkdir(dir);
+    // macOS resolves /var to /private/var; lsof reports the resolved path.
+    const expected = await fs.promises.realpath(dir);
+
+    const child = spawn("sleep", ["30"], { cwd: expected, stdio: "ignore" });
+    try {
+      await new Promise((resolve, reject) => child.once("spawn", resolve).once("error", reject));
+      // The C locale is what a GUI-launched server inherits, and it is what
+      // made lsof hand back "\xe4\xbb\xa3\xe7\xa0\x81" instead of 代码.
+      const found = await cwdForPid(child.pid!, { ...process.env, LC_ALL: "C", LANG: "C" });
+      assert.equal(found, expected);
+    } finally {
+      child.kill("SIGKILL");
+      await fs.promises.rm(base, { recursive: true, force: true });
+    }
+  },
+);
+
+test("returns undefined for a pid that no longer exists", async () => {
+  // Not a real pid: the kernel reserves 0, so nothing can be looked up under it.
+  assert.equal(await cwdForPid(0), undefined);
+});

--- a/apps/server/src/processCwd.ts
+++ b/apps/server/src/processCwd.ts
@@ -1,0 +1,65 @@
+/**
+ * A live process's working directory, read from the OS.
+ *
+ * Linux has /proc/<pid>/cwd. macOS has no equivalent, so this shells out to
+ * lsof — and lsof's output depends on the locale it runs in, which is where
+ * the interesting part is (see below).
+ */
+import { execFile } from "node:child_process";
+import fs from "node:fs";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * The environment to run lsof in, so it reports paths as they are on disk.
+ *
+ * lsof renders bytes it considers non-printable as literal `\xNN` escapes, and
+ * under the C locale every byte of a non-ASCII path qualifies: a directory
+ * named 代码 comes back as the 24-character string `\xe4\xbb\xa3\xe7\xa0\x81`.
+ * Callers then stat that string, get ENOENT, and conclude the process has no
+ * working directory — so on a machine whose projects live under non-ASCII
+ * paths, every cwd-derived feature quietly degrades to the home directory.
+ *
+ * The C locale is not a corner case here: a desktop app launched from the GUI
+ * inherits launchd's environment, which sets no LANG at all, while the user's
+ * own shell is UTF-8. The server therefore sees escaped paths for exactly the
+ * directories the user works in.
+ *
+ * LC_ALL outranks LC_CTYPE, so an inherited `LC_ALL=C` has to be dropped rather
+ * than merely overridden — leaving it keeps the escaping. LANG is outranked by
+ * LC_CTYPE and can stay as the user set it.
+ */
+export function lsofEnvironment(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const next: NodeJS.ProcessEnv = { ...env, LC_CTYPE: "UTF-8" };
+  delete next.LC_ALL;
+  return next;
+}
+
+/**
+ * The working directory of `pid`, or undefined when it can't be read (the
+ * process is gone, lsof is missing or slow, or the platform has neither path).
+ */
+export async function cwdForPid(
+  pid: number,
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+): Promise<string | undefined> {
+  try {
+    if (platform === "linux") return await fs.promises.realpath(`/proc/${pid}/cwd`);
+    if (platform === "darwin") {
+      const { stdout } = await execFileAsync("lsof", ["-a", "-d", "cwd", "-p", String(pid), "-Fn"], {
+        timeout: 1000,
+        maxBuffer: 4096,
+        env: lsofEnvironment(env),
+      });
+      const line = stdout
+        .split("\n")
+        .find((value) => value.startsWith("n") && value.length > 1);
+      return line?.slice(1);
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}


### PR DESCRIPTION
## What's broken

On macOS a pane's working directory is read with `lsof -Fn`, and lsof renders bytes it
considers non-printable as literal `\xNN` escapes. Under the C locale every byte of a
non-ASCII path qualifies, so a pane sitting in a directory named `代码` is reported as:

```
/Users/me/\xe4\xbb\xa3\xe7\xa0\x81
```

Callers stat that string, get ENOENT, and conclude the pane has no working directory.

The C locale is not a corner case for a desktop app: a GUI launch inherits launchd's
environment, which sets no `LANG` at all, while the user's shell is UTF-8. So on a machine
whose projects live under non-ASCII paths, the server loses every cwd it is asked for:

- new panes and splits open in the home directory instead of inheriting one
- the file tree, the git panel and the worktree panel follow the wrong directory
- `sweepCwds()` persists nothing, so reopening the app does not return a pane to where it was

Reproduced on 0.1.29 with the app's own bundled node and its exact environment:

```
LANG unset       → "/Volumes/…/mac/\xe4\xbb\xa3\xe7\xa0\x81"   stat → ENOENT
LC_CTYPE=UTF-8   → "/Volumes/…/mac/代码"                        stat → OK
```

On the reporting machine `session_cwd` held 9 rows for 27 panes, and every one of them was
a pure-ASCII path — the non-ASCII ones had been silently dropped for as long as the app had
been installed.

## The fix

Run lsof with a UTF-8 `LC_CTYPE`, which makes it pass the bytes through unchanged.

`LC_ALL` outranks `LC_CTYPE`, so an inherited `LC_ALL=C` is dropped rather than overridden —
leaving it in place keeps the escaping and the fix would look applied while doing nothing.
`LANG` is outranked and is left as the user set it.

Decoding the escapes ourselves was considered and rejected: it would have to guess whether a
literal backslash in a file name came from lsof or from the file.

## Tests

The lookup moves to `processCwd.ts` so it can be tested against a live process. The added
test spawns one in a directory named `代码`, asks for its cwd with `LC_ALL=C`, and fails on
the previous code with exactly the escaped string above.

`npm -w @termany/server test`: 84 passing.

## Scope

Server only, macOS only in effect — Linux reads `/proc/<pid>/cwd` and is unchanged, Windows
has neither path and still falls back to its OSC 7 reports. No API, schema or client change.
