### PR TITLE
feat(server): tell a respawned pane what was there before it

### DIFF
--- a/apps/server/src/db.ts
+++ b/apps/server/src/db.ts
@@ -26,6 +26,7 @@ db.exec(`
   CREATE TABLE IF NOT EXISTS session_cwd (id TEXT PRIMARY KEY, cwd TEXT NOT NULL);
   CREATE TABLE IF NOT EXISTS session_scroll (id TEXT PRIMARY KEY, data TEXT NOT NULL);
   CREATE TABLE IF NOT EXISTS session_screen (id TEXT PRIMARY KEY, data TEXT NOT NULL, updated_at INTEGER NOT NULL DEFAULT 0);
+  CREATE TABLE IF NOT EXISTS session_agent (id TEXT PRIMARY KEY, agent TEXT NOT NULL, updated_at INTEGER NOT NULL);
 `);
 // updated_at orders the prune below (added after 0.1.3 shipped, so migrate).
 try {
@@ -135,6 +136,31 @@ export function setSessionCwd(id: string, cwd: string): void {
   ).run(id, cwd);
 }
 
+export interface SessionAgentRecord {
+  agent: string;
+  /** When the agent was last observed running in this pane. */
+  updatedAt: number;
+}
+
+/**
+ * Which agent CLI was last seen in a pane. Survives a reboot, which is the
+ * point: the shell does not, so this is all that is left to tell the user what
+ * the pane was doing before the machine went down.
+ */
+export function getSessionAgent(id: string): SessionAgentRecord | null {
+  const row = db.prepare("SELECT agent, updated_at FROM session_agent WHERE id = ?").get(id) as
+    | { agent: string; updated_at: number }
+    | undefined;
+  return row ? { agent: row.agent, updatedAt: row.updated_at } : null;
+}
+
+export function setSessionAgent(id: string, agent: string, updatedAt: number): void {
+  db.prepare(
+    "INSERT INTO session_agent(id, agent, updated_at) VALUES(?, ?, ?) " +
+      "ON CONFLICT(id) DO UPDATE SET agent = excluded.agent, updated_at = excluded.updated_at"
+  ).run(id, agent, updatedAt);
+}
+
 /** All saved scroll histories, as an `{ id: data }` map — for startup prime. */
 export function getAllScroll(): Record<string, string> {
   const rows = db.prepare("SELECT id, data FROM session_scroll").all() as {
@@ -217,10 +243,12 @@ export function forgetSessions(ids: string[]): void {
     const delCwd = db.prepare("DELETE FROM session_cwd WHERE id = ?");
     const delScroll = db.prepare("DELETE FROM session_scroll WHERE id = ?");
     const delScreen = db.prepare("DELETE FROM session_screen WHERE id = ?");
+    const delAgent = db.prepare("DELETE FROM session_agent WHERE id = ?");
     for (const id of ids) {
       delCwd.run(String(id));
       delScroll.run(String(id));
       delScreen.run(String(id));
+      delAgent.run(String(id));
     }
     db.exec("COMMIT");
   } catch (e) {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -38,16 +38,19 @@ import {
   getAllScreens,
   getAllScroll,
   getScroll,
+  getSessionAgent,
   getSessionCwd,
   loadState,
   saveState,
   setScreenBatch,
   setScrollBatch,
+  setSessionAgent,
   setSessionCwd,
 } from "./db.js";
 import { gitDiffs, gitOverview, worktreeOverview } from "./git.js";
 import { pickFolder } from "./folderPicker.js";
 import { testProvider } from "./providerTest.js";
+import { collectPaneHistory, formatPaneHistory } from "./paneHistory.js";
 import { ptyEnvironment } from "./ptyEnvironment.js";
 import { resolveExecutable } from "./shellPath.js";
 import { generateTheme } from "./theme.js";
@@ -1687,25 +1690,30 @@ async function acpTarget(body: any): Promise<AcpRuntimeTarget> {
 }
 
 /**
- * Record every live session's working directory so a respawned shell can return
- * to it after the app is closed and reopened. Runs on an interval (the app may
- * be SIGKILLed on quit, so we can't rely on a shutdown hook) and once at exit.
+ * Record what is knowable about every live session from the outside — where its
+ * shell is, and which agent CLI is running in it — so a respawned shell can
+ * return to that directory and say what was there before.
+ *
+ * Runs on an interval (the app may be SIGKILLed on quit, so we can't rely on a
+ * shutdown hook) and once at exit. A machine that loses power keeps whatever
+ * the last tick saw, which is the case this exists for.
  */
-async function sweepCwds(): Promise<void> {
+async function sweepSessionState(): Promise<void> {
+  const activities = activityTracker.snapshot();
   for (const [id, session] of ptySessions) {
     const cwd = await dirIfValid(await cwdForPid(session.pty.pid));
-    if (cwd) {
-      try {
-        setSessionCwd(id, cwd);
-      } catch {
-        /* DB busy — next sweep will catch it */
-      }
+    const agent = activities[id]?.agent;
+    try {
+      if (cwd) setSessionCwd(id, cwd);
+      if (agent) setSessionAgent(id, agent, Date.now());
+    } catch {
+      /* DB busy — next sweep will catch it */
     }
   }
 }
 
 setInterval(() => {
-  void sweepCwds();
+  void sweepSessionState();
 }, 5000).unref();
 
 wss.on("connection", async (ws: WebSocket, req) => {
@@ -1863,6 +1871,22 @@ wss.on("connection", async (ws: WebSocket, req) => {
   }
 
   const cwd = await resolveSpawnCwd(url.searchParams.get("cwdFrom"), sessionId, true);
+  // What this pane was doing before its last shell died. Gathered before the
+  // spawn so it can be printed ahead of the shell's first output instead of
+  // landing in the middle of it. Local panes only: an ssh pane's directory and
+  // transcripts belong to the machine on the other end.
+  const banner =
+    sessionId && !sshTarget
+      ? formatPaneHistory(
+          await collectPaneHistory(sessionId, {
+            getCwd: getSessionCwd,
+            getAgent: getSessionAgent,
+            listSessions: async (agentId, root, limit) =>
+              (await listAgentSessions(agentId, [root], 0, limit)).sessions ?? [],
+          }),
+          Date.now(),
+        )
+      : "";
   if (closed) return;
 
   let pty: ReturnType<typeof spawn>;
@@ -1898,6 +1922,12 @@ wss.on("connection", async (ws: WebSocket, req) => {
     sshPortForwarding.register(sessionId, sshConnectionArgs, sshControlPath);
   }
   if (sessionId) activityTracker.bindAgent(sessionId, agent);
+  // Into the ring as well as the socket, so it survives a page reload the same
+  // way the rest of this pane's history does.
+  if (banner) {
+    ringAppend(session.ring, banner);
+    if (ws.readyState === ws.OPEN) ws.send(banner);
+  }
   wireSession(sessionId ?? undefined, session);
 
   pendingMessages.splice(0).forEach(applyClientMessage);
@@ -1911,7 +1941,7 @@ wss.on("connection", async (ws: WebSocket, req) => {
 async function shutdown() {
   // Best-effort: capture the final working directories before the shells die, so
   // a clean quit restores them exactly. Bounded so we never hang the exit.
-  await Promise.race([sweepCwds(), new Promise((r) => setTimeout(r, 800))]).catch(() => {});
+  await Promise.race([sweepSessionState(), new Promise((r) => setTimeout(r, 800))]).catch(() => {});
   flushScroll();
   for (const session of ptySessions.values()) {
     try {

--- a/apps/server/src/paneHistory.test.ts
+++ b/apps/server/src/paneHistory.test.ts
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { AgentSession } from "./agentSessions.js";
+import { collectPaneHistory, formatPaneHistory, timeAgo } from "./paneHistory.js";
+
+const NOW = 1_700_000_000_000;
+const HOUR = 3_600_000;
+
+function session(overrides: Partial<AgentSession> = {}): AgentSession {
+  return {
+    sessionId: "b863562d-1f4e-4b0a-9d55-2f6a1c7e8a90",
+    cwd: "/work/项目",
+    preview: "当前进度是啥，你看下远端最新情况",
+    mtimeMs: NOW - 3 * HOUR,
+    totalTokens: null,
+    contextTokens: null,
+    gitBranch: "main",
+    ...overrides,
+  };
+}
+
+test("a pane that never ran an agent opens silently", () => {
+  assert.equal(formatPaneHistory({ sessions: [] }, NOW), "");
+});
+
+test("reports the directory and the agent", () => {
+  const out = formatPaneHistory(
+    { cwd: "/work/项目", agent: "claude", agentLastSeen: NOW - HOUR, sessions: [] },
+    NOW,
+  );
+  assert.match(out, /directory {2}\/work\/项目/);
+  assert.match(out, /agent {6}claude, last seen 1 hour ago/);
+});
+
+test("prints the whole session id, since the point is to paste it", () => {
+  const s = session();
+  const out = formatPaneHistory({ cwd: "/work/项目", agent: "claude", sessions: [s] }, NOW);
+  assert.match(out, new RegExp(`claude --resume ${s.sessionId}`));
+  assert.match(out, /3 hours ago · main/);
+  assert.match(out, /当前进度是啥/);
+});
+
+test("codex transcripts get codex's own resume syntax", () => {
+  const out = formatPaneHistory({ cwd: "/w", agent: "codex", sessions: [session()] }, NOW);
+  assert.match(out, /codex resume /);
+});
+
+test("an unknown agent still shows the id rather than inventing a command", () => {
+  const out = formatPaneHistory({ cwd: "/w", agent: "opencode", sessions: [session()] }, NOW);
+  assert.ok(!out.includes("--resume"), "must not guess a resume flag");
+  assert.match(out, /b863562d-1f4e-4b0a-9d55-2f6a1c7e8a90/);
+});
+
+test("says which one ran here is unknown only when there is a choice to make", () => {
+  const one = formatPaneHistory({ cwd: "/w", agent: "claude", sessions: [session()] }, NOW);
+  assert.ok(!one.includes("not recorded:"), "a single candidate needs no caveat");
+
+  const many = formatPaneHistory(
+    { cwd: "/w", agent: "claude", sessions: [session(), session({ sessionId: "other" })] },
+    NOW,
+  );
+  assert.match(many, /which one ran here is not recorded/);
+});
+
+test("admits an unrecorded directory instead of implying the home directory", () => {
+  const out = formatPaneHistory({ agent: "claude", sessions: [] }, NOW);
+  assert.match(out, /directory {2}not recorded/);
+});
+
+test("flags a transcript whose directory has since been deleted", () => {
+  const out = formatPaneHistory(
+    { cwd: "/w", agent: "claude", sessions: [session({ cwdMissing: true })] },
+    NOW,
+  );
+  assert.match(out, /directory is gone/);
+});
+
+test("every line ends CRLF, or a raw PTY renders a staircase", () => {
+  const out = formatPaneHistory({ cwd: "/w", agent: "claude", sessions: [session()] }, NOW);
+  const bareNewlines = out.split("\n").filter((part, i, all) => i < all.length - 1 && !part.endsWith("\r"));
+  assert.deepEqual(bareNewlines, []);
+});
+
+test("timeAgo stays coarse", () => {
+  assert.equal(timeAgo(NOW - 30_000, NOW), "just now");
+  assert.equal(timeAgo(NOW - 5 * 60_000, NOW), "5 minutes ago");
+  assert.equal(timeAgo(NOW - HOUR, NOW), "1 hour ago");
+  assert.equal(timeAgo(NOW - 50 * HOUR, NOW), "2 days ago");
+});
+
+const deps = (overrides: Partial<Parameters<typeof collectPaneHistory>[1]> = {}) => ({
+  getCwd: () => "/work/项目",
+  getAgent: () => ({ agent: "claude", updatedAt: NOW - HOUR }),
+  listSessions: async () => [session()],
+  ...overrides,
+});
+
+test("collects the record and its candidate transcripts", async () => {
+  const history = await collectPaneHistory("pane-1", deps());
+  assert.equal(history.agent, "claude");
+  assert.equal(history.cwd, "/work/项目");
+  assert.equal(history.sessions.length, 1);
+});
+
+test("a pane with no agent on record looks up no transcripts at all", async () => {
+  let called = false;
+  const history = await collectPaneHistory(
+    "pane-1",
+    deps({
+      getAgent: () => null,
+      listSessions: async () => {
+        called = true;
+        return [];
+      },
+    }),
+  );
+  assert.deepEqual(history, { sessions: [] });
+  assert.equal(called, false, "scanning a transcript store for nothing is pure cost");
+});
+
+test("without a directory there is nothing to scope a search to", async () => {
+  let called = false;
+  const history = await collectPaneHistory(
+    "pane-1",
+    deps({
+      getCwd: () => null,
+      listSessions: async () => {
+        called = true;
+        return [];
+      },
+    }),
+  );
+  assert.equal(history.agent, "claude");
+  assert.equal(called, false);
+});
+
+test("a slow transcript scan is abandoned, not waited out", async () => {
+  const history = await collectPaneHistory(
+    "pane-1",
+    deps({ listSessions: () => new Promise(() => {}), timeoutMs: 5 }),
+  );
+  // The pane still learns where it was and what ran there.
+  assert.equal(history.cwd, "/work/项目");
+  assert.deepEqual(history.sessions, []);
+});
+
+test("a failed lookup still yields a banner", async () => {
+  const history = await collectPaneHistory(
+    "pane-1",
+    deps({ listSessions: async () => { throw new Error("unreadable"); } }),
+  );
+  assert.equal(history.agent, "claude");
+  assert.deepEqual(history.sessions, []);
+});
+
+test("a broken database never keeps a pane from opening", async () => {
+  const history = await collectPaneHistory(
+    "pane-1",
+    deps({ getAgent: () => { throw new Error("db locked"); } }),
+  );
+  assert.deepEqual(history, { sessions: [] });
+});

--- a/apps/server/src/paneHistory.ts
+++ b/apps/server/src/paneHistory.ts
@@ -1,0 +1,172 @@
+/**
+ * What a pane was doing before its shell died, printed into the new one.
+ *
+ * A pane's layout, title and scrollback survive a reboot; the shell inside it
+ * does not, and neither does the agent CLI that was running there. The user is
+ * left with a grid of panes that look right and know nothing — the directory
+ * is gone, and so is any pointer to the conversation that was open, which on a
+ * busy machine means picking one of dozens of transcripts by guesswork.
+ *
+ * So the new shell opens with a note about the old one. Deliberately just a
+ * note: nothing is resumed, nothing is typed into the shell. Restarting an
+ * agent is the user's call, and a banner that acted on its own would be a
+ * command the user never issued running in a pane they only just opened.
+ *
+ * The pairing of pane to transcript is *not* recorded anywhere — the agent CLIs
+ * do not publish their session id, and inferring it from a directory is a guess
+ * whenever two panes share one. This module therefore reports candidates and
+ * says plainly that it cannot tell them apart, rather than naming one and being
+ * confidently wrong.
+ */
+import type { AgentSession } from "./agentSessions.js";
+import type { SessionAgentRecord } from "./db.js";
+
+export interface PaneHistory {
+  /** Where the pane's shell was, as of the last sweep before it died. */
+  cwd?: string;
+  /** The agent CLI last seen running there. */
+  agent?: string;
+  /** When that agent was last observed, in epoch ms. */
+  agentLastSeen?: number;
+  /** That agent's transcripts under `cwd`, newest first. */
+  sessions: AgentSession[];
+}
+
+export interface PaneHistoryDeps {
+  getCwd(paneId: string): string | null;
+  getAgent(paneId: string): SessionAgentRecord | null;
+  listSessions(agent: string, root: string, limit: number): Promise<AgentSession[]>;
+  /** Transcript stores grow without bound; never hold a new pane open for one. */
+  timeoutMs?: number;
+  now?: () => number;
+}
+
+/** How many transcripts to offer before the list stops being an aid. */
+const MAX_CANDIDATES = 3;
+const DEFAULT_TIMEOUT_MS = 1_500;
+const PREVIEW_CHARS = 54;
+
+const DIM = "\x1b[2m";
+const RESET = "\x1b[0m";
+
+/**
+ * Gather what is known about a pane's previous life. Never throws and never
+ * blocks for long: a pane that opens late or without its banner is a far
+ * smaller failure than a pane that will not open.
+ */
+export async function collectPaneHistory(
+  paneId: string,
+  deps: PaneHistoryDeps,
+): Promise<PaneHistory> {
+  let record: SessionAgentRecord | null = null;
+  let cwd: string | null = null;
+  try {
+    record = deps.getAgent(paneId);
+    cwd = deps.getCwd(paneId);
+  } catch {
+    /* the DB is a nicety here, not a dependency of opening a shell */
+  }
+  if (!record) return { sessions: [] };
+
+  const history: PaneHistory = {
+    cwd: cwd ?? undefined,
+    agent: record.agent,
+    agentLastSeen: record.updatedAt,
+    sessions: [],
+  };
+  if (!cwd) return history;
+
+  const timeoutMs = deps.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  // Not unref'd: an unref'd timer stops holding the loop open, and a lookup
+  // that never settles would then leave this race pending forever.
+  const expired = new Promise<AgentSession[]>((resolve) => {
+    timer = setTimeout(() => resolve([]), timeoutMs);
+  });
+  try {
+    history.sessions = await Promise.race([
+      deps.listSessions(record.agent, cwd, MAX_CANDIDATES).catch(() => []),
+      expired,
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+  return history;
+}
+
+/** "3 hours ago" — coarse on purpose; the exact minute is never the question. */
+export function timeAgo(thenMs: number, nowMs: number): string {
+  const seconds = Math.max(0, Math.round((nowMs - thenMs) / 1000));
+  if (seconds < 90) return "just now";
+  const units: [number, string][] = [
+    [60, "minute"],
+    [3600, "hour"],
+    [86400, "day"],
+  ];
+  let size = 60;
+  let name = "minute";
+  for (const [unitSeconds, unitName] of units) {
+    if (seconds >= unitSeconds) {
+      size = unitSeconds;
+      name = unitName;
+    }
+  }
+  const count = Math.round(seconds / size);
+  return `${count} ${name}${count === 1 ? "" : "s"} ago`;
+}
+
+/** One line of transcript text, short enough to sit beside a resume command. */
+function preview(text: string): string {
+  const flat = text.replace(/\s+/gu, " ").trim();
+  if (!flat) return "";
+  return flat.length > PREVIEW_CHARS ? `${flat.slice(0, PREVIEW_CHARS - 1)}…` : flat;
+}
+
+/** The command that reopens a transcript, per agent. Empty when unknown. */
+function resumeCommand(agent: string, sessionId: string): string {
+  if (agent === "claude") return `claude --resume ${sessionId}`;
+  if (agent === "codex") return `codex resume ${sessionId}`;
+  return "";
+}
+
+/**
+ * Render the banner, or "" when there is nothing to say — a pane that never
+ * ran an agent must open silently, exactly as it does today.
+ *
+ * Lines end with CRLF: this is written to a raw PTY, where a bare LF drops to
+ * the next row without returning to column one and the banner comes out as a
+ * staircase.
+ */
+export function formatPaneHistory(history: PaneHistory, nowMs: number): string {
+  if (!history.agent) return "";
+  const lines: string[] = [];
+  const seen = history.agentLastSeen ? `, last seen ${timeAgo(history.agentLastSeen, nowMs)}` : "";
+
+  // Not "before the restart": the same banner greets a pane whose shell merely
+  // exited, and telling the user a reboot happened when none did is a lie.
+  lines.push(`─ previously in this pane ${"─".repeat(35)}`);
+  lines.push(`  directory  ${history.cwd ?? "not recorded"}`);
+  lines.push(`  agent      ${history.agent}${seen}`);
+
+  if (history.sessions.length) {
+    lines.push(
+      history.sessions.length === 1
+        ? "  its most recent transcript in that directory:"
+        : "  recent transcripts in that directory — which one ran here is not recorded:",
+    );
+    for (const session of history.sessions) {
+      const command = resumeCommand(history.agent, session.sessionId) || session.sessionId;
+      const facts = [timeAgo(session.mtimeMs, nowMs), session.gitBranch, session.cwdMissing ? "directory is gone" : null]
+        .filter(Boolean)
+        .join(" · ");
+      lines.push(`    ${command}`);
+      const note = preview(session.preview);
+      lines.push(`      ${facts}${note ? `  ${note}` : ""}`);
+    }
+  } else if (history.cwd) {
+    lines.push(`  no ${history.agent} transcript found under that directory`);
+  }
+  lines.push("─".repeat(60));
+
+  return `\r\n${lines.map((line) => `${DIM}${line}${RESET}\r\n`).join("")}\r\n`;
+}


### PR DESCRIPTION
## The problem

A pane survives a reboot as a rectangle with the right title and none of its contents. The
layout, scrollback and directory are in the database; the shell is not, and neither is the
agent CLI that was running in it.

What the user gets back is a grid of panes that look right and know nothing. Finding the
conversation that belonged to one means picking a session id out of dozens by guesswork —
on a machine with 27 panes and a few hundred transcripts, that is the difference between
resuming work and starting over.

## What this adds

A freshly spawned pane opens with a note about its previous life:

```
─ previously in this pane ───────────────────────────
  directory  /Volumes/…/leinao/agent-product-platform
  agent      claude, last seen 2 hours ago
  recent transcripts in that directory — which one ran here is not recorded:
    claude --resume b863562d-3d1e-450a-b472-22bad9dedb64
      26 minutes ago · main  This session is being continued from a previous conve…
    claude --resume c61126ff-b9e3-4bba-a96f-8a6ce5396b0d
      1 day ago · main  ## 一、页面中出现的知识库 …
─────────────────────────────────────────────────────
```

Session ids are printed in full, because the point is to be able to paste one.

## Three decisions worth reviewing

**It only reports.** Nothing is resumed, nothing is typed into the shell. Restarting an agent
is the user's call, and a pane that ran a command the user never issued the moment it opened
would be worse than one that forgot.

**It admits what it does not know.** Which transcript belonged to which pane is recorded
nowhere — the agent CLIs do not publish their session id, so pairing them is a guess as soon
as two panes share a directory. The banner lists candidates and says outright that it cannot
tell them apart, rather than naming one and being confidently wrong. With a single candidate
the caveat is dropped.

**It cannot delay or break a pane.** The transcript lookup is bounded (1.5s) and its failures
are swallowed; a DB error means no banner at all. A pane that opens without its note is a much
smaller failure than a pane that will not open.

## How it works

The existing 5-second sweep already captured each live pane's cwd for restore. It now also
records the agent the activity tracker recognised, in a new `session_agent` table (dropped by
`/api/forget` with the rest of a pane's restore data). That is the only part that has to be
observed while the machine is still up.

The banner is assembled before the spawn, so it prints ahead of the shell's first output
instead of landing in the middle of it, and is written to the scroll ring as well as the
socket so it survives a page reload. Skipped for ssh panes — their directory and transcripts
belong to the machine on the other end.

Candidates come from the existing `listAgentSessions()` reader, scoped to the pane's
directory, so claude and codex are covered with no new transcript parsing.

## Tests

16 new tests covering the rendering (including CRLF line endings, without which a raw PTY
renders a staircase) and the gathering (timeout, lookup failure, DB failure, and the two cases
where no lookup should happen at all).

`npm -w @termany/server test`: 94 passing.

Verified against a running server with an isolated HOME: a seeded pane opened in a directory
whose name is not ASCII, printed its three candidate transcripts, and landed the shell back in
that directory.
