### PR TITLE
[修复]窗口隐藏/最小化一段时间口，终端最下方的一块区域空白

### DIFF
--- a/apps/web/src/terminal/manager.ts
+++ b/apps/web/src/terminal/manager.ts
@@ -1892,6 +1892,12 @@ export function fitSession(id: string) {
   id = activeSessionId(id);
   const s = sessions.get(id);
   if (!s || !s.opened) return;
+  // A minimized/hidden window lays out as (near-)zero size. Fitting then
+  // clamps the terminal to FitAddon's 2x1 minimum, which reflows the live
+  // screen into scrollback (and mangles ConPTY's buffer) — the "current
+  // screen is blank after showing the window again" bug. Skip degenerate
+  // measurements; the ResizeObserver fires a real fit once the layout is back.
+  if (s.el.isConnected && (s.el.clientWidth < 5 || s.el.clientHeight < 5)) return;
   try {
     s.fit.fit();
     s.backend.resize(s.term.cols, s.term.rows);


### PR DESCRIPTION
# 原因
窗口隐藏/最小化的瞬间，WebView2 布局塌缩成 0×0 → TerminalPane 的 ResizeObserver 触发 fitSession → fit() 量出 0 尺寸，被 FitAddon 钳到最小值 2x1 → xterm 把当前屏的行全部挤进 scrollback，ConPTY 的缓冲区也被打烂。窗口恢复时 resize 回71x23，但被挤走的行不会自动拉回来。于是：

   • 当前屏空白，往上滚动内容都在（行只是搬进了 scrollback）
   • 复制空白区域是空的（buffer 里那些行确实是空行） "复制为空"把方向纠正到了 resize 塌陷上
   • 手动 resize 不恢复（此时尺寸已正常，fit() 是空操作）
   • 滚动也不恢复（数据层面内容已经搬走了）
 
错误原因是让AI加日志，我手动测试，复现问题，收集日志，让AI分析得到的。

# 修复

apps/web/src/terminal/manager.ts 的 fitSession()：量到容器宽<5或高<5时直接跳过（布局恢复后 ResizeObserver 会补一次正常的 fit）。这样隐藏期间 xterm 和 PTY 的尺寸都保持不动，屏幕内容原地不动。