### PR TITLE
feat: OSC 52 clipboard + in-band file transfer (trzsz)

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -12,6 +12,7 @@
     "@agentclientprotocol/sdk": "^1.2.1",
     "@anthropic-ai/sdk": "^0.106.0",
     "node-pty": "^1.0.0",
+    "trzsz": "^1.1.6",
     "undici": "^8.5.0",
     "ws": "^8.18.0"
   },

--- a/apps/server/src/filePicker.ts
+++ b/apps/server/src/filePicker.ts
@@ -1,0 +1,76 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+/** Escape a string into an AppleScript double-quoted literal. */
+function appleScriptString(value: string): string {
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+/**
+ * Open the OS-native "choose files" dialog and return the picked absolute
+ * paths, or null when the user cancels. Like pickFolder, the dialog belongs
+ * to the machine the server runs on (Tauri shell or `pnpm dev:web`), so it
+ * appears locally even when the UI itself lives in a browser tab.
+ */
+export async function pickFiles(prompt: string): Promise<string[] | null> {
+  if (process.platform === "darwin") {
+    const script = [
+      `set chosenFiles to choose file with prompt ${appleScriptString(prompt)} with multiple selections allowed`,
+      "set outList to {}",
+      "if class of chosenFiles is list then",
+      "  repeat with f in chosenFiles",
+      "    set end of outList to POSIX path of f",
+      "  end repeat",
+      "else",
+      "  set end of outList to POSIX path of chosenFiles",
+      "end if",
+      "set AppleScript's text item delimiters to linefeed",
+      "return outList as text",
+    ].join("\n");
+    try {
+      const pending = execFileAsync("osascript", ["-e", script], { timeout: 300_000 });
+      execFileAsync("osascript", [
+        "-e",
+        'tell application "System Events" to set frontmost of (first process whose name is "osascript") to true',
+      ]).catch(() => undefined);
+      const { stdout } = await pending;
+      const paths = stdout.split("\n").map((p) => p.trim()).filter(Boolean);
+      return paths.length ? paths : null;
+    } catch (error) {
+      const detail =
+        error instanceof Error ? String((error as { stderr?: string }).stderr ?? error.message) : String(error);
+      if (detail.includes("-128")) return null; // user canceled
+      throw new Error(`File dialog failed: ${detail.trim()}`);
+    }
+  }
+
+  if (process.platform === "win32") {
+    const script = [
+      "Add-Type -AssemblyName System.Windows.Forms;",
+      "$d = New-Object System.Windows.Forms.OpenFileDialog;",
+      "$d.Multiselect = $true;",
+      `$d.Title = '${prompt.replace(/'/g, "''")}';`,
+      "if ($d.ShowDialog() -eq 'OK') { $d.FileNames -join [char]10 }",
+    ].join(" ");
+    const { stdout } = await execFileAsync("powershell.exe", ["-NoProfile", "-Command", script], {
+      timeout: 300_000,
+    });
+    const paths = stdout.split(/\r?\n/).map((p) => p.trim()).filter(Boolean);
+    return paths.length ? paths : null;
+  }
+
+  // Linux: best effort via zenity; a missing binary surfaces as a clear error.
+  try {
+    const args = ["--file-selection", "--multiple", "--separator=\n", `--title=${prompt}`];
+    const { stdout } = await execFileAsync("zenity", args, { timeout: 300_000 });
+    const paths = stdout.split("\n").map((p) => p.trim()).filter(Boolean);
+    return paths.length ? paths : null;
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && (error as { code?: number }).code === 1) {
+      return null; // canceled
+    }
+    throw new Error("File dialog needs zenity on this system");
+  }
+}

--- a/apps/server/src/fileTransfer.test.ts
+++ b/apps/server/src/fileTransfer.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createTransferPipeline,
+  stripTransferMagic,
+  type TransferFilter,
+  type TransferHost,
+  type TransferProtocol,
+} from "./fileTransfer.js";
+
+/**
+ * A protocol that takes over as soon as it sees `<name>!` in the stream, and
+ * stays taken over until it sees `.` — enough shape to test routing without
+ * dragging a real wire format in.
+ */
+function fakeProtocol(name: string, options: { canInitiateUpload?: boolean } = {}): TransferProtocol {
+  return {
+    name,
+    magic: new RegExp(`${name}!`),
+    canInitiateUpload: options.canInitiateUpload ?? false,
+    create(host: TransferHost): TransferFilter {
+      let transferring = false;
+      return {
+        fromShell(data) {
+          if (data.includes(`${name}!`)) {
+            transferring = true;
+            host.sendToClient(`<${name} took over>`);
+            return;
+          }
+          if (transferring) {
+            if (data.includes(".")) transferring = false;
+            host.sendToPty(`${name}-ack`);
+            return;
+          }
+          host.sendToClient(data);
+        },
+        fromClient(data) {
+          if (!transferring) return false;
+          host.sendToPty(`${name}-cancel:${data}`);
+          return true;
+        },
+        async startUpload(paths) {
+          host.sendToPty(`${name}-upload:${paths.join(",")}`);
+        },
+        setColumns(cols) {
+          host.sendToClient(`<${name} cols ${cols}>`);
+        },
+      };
+    },
+  };
+}
+
+function pipe(protocols: TransferProtocol[]) {
+  const toPty: string[] = [];
+  const toClient: string[] = [];
+  return {
+    toPty,
+    toClient,
+    pipeline: createTransferPipeline({
+      protocols,
+      sendToPty: (data) => toPty.push(data),
+      sendToClient: (data) => toClient.push(data),
+    }),
+  };
+}
+
+test("an empty pipeline is a pass-through in both directions", () => {
+  const p = pipe([]);
+  p.pipeline.fromShell("hello\r\n");
+  assert.deepEqual(p.toClient, ["hello\r\n"]);
+  // Nothing claims the keystrokes, so the caller is the one that writes them.
+  assert.equal(p.pipeline.fromClient("ls\r"), false);
+  assert.deepEqual(p.toPty, []);
+});
+
+test("output a protocol does not recognize reaches the client through every filter", () => {
+  const p = pipe([fakeProtocol("alpha"), fakeProtocol("beta")]);
+  p.pipeline.fromShell("plain output\r\n");
+  assert.deepEqual(p.toClient, ["plain output\r\n"]);
+});
+
+test("the filter that recognizes a handshake takes the stream over", () => {
+  const p = pipe([fakeProtocol("alpha"), fakeProtocol("beta")]);
+  p.pipeline.fromShell("beta!");
+  assert.deepEqual(p.toClient, ["<beta took over>"]);
+
+  // While it holds the stream, the payload never reaches the client, and
+  // keystrokes go to the protocol instead of the shell.
+  p.pipeline.fromShell("payload");
+  assert.deepEqual(p.toClient, ["<beta took over>"]);
+  assert.deepEqual(p.toPty, ["beta-ack"]);
+  assert.equal(p.pipeline.fromClient("\x03"), true);
+  assert.deepEqual(p.toPty, ["beta-ack", "beta-cancel:\x03"]);
+
+  // Transfer over: the stream is transparent again.
+  p.pipeline.fromShell("done.");
+  p.pipeline.fromShell("back to normal\r\n");
+  assert.ok(p.toClient.includes("back to normal\r\n"));
+  assert.equal(p.pipeline.fromClient("ls\r"), false);
+});
+
+test("a pane whose protocols cannot start an upload refuses one", async () => {
+  const p = pipe([fakeProtocol("alpha")]);
+  assert.equal(p.pipeline.canUpload, false);
+  await assert.rejects(p.pipeline.startUpload(["/tmp/a"]));
+});
+
+test("an upload goes to the first protocol that can start one", async () => {
+  const p = pipe([fakeProtocol("alpha"), fakeProtocol("beta", { canInitiateUpload: true })]);
+  assert.equal(p.pipeline.canUpload, true);
+  await p.pipeline.startUpload(["/tmp/a", "/tmp/b"]);
+  assert.deepEqual(p.toPty, ["beta-upload:/tmp/a,/tmp/b"]);
+});
+
+test("a resize reaches every protocol's progress bar", () => {
+  const p = pipe([fakeProtocol("alpha"), fakeProtocol("beta")]);
+  p.pipeline.setColumns(120);
+  assert.deepEqual(p.toClient.sort(), ["<alpha cols 120>", "<beta cols 120>"]);
+});
+
+test("replayed scrollback carries no transfer handshake", () => {
+  const magic = "\x1b7\x07::TRZSZ:TRANSFER:S:1.2.3:0000000000001\r\n";
+  assert.equal(stripTransferMagic(`before${magic}after`), "beforeafter");
+  assert.equal(stripTransferMagic("ordinary output\r\n"), "ordinary output\r\n");
+});

--- a/apps/server/src/fileTransfer.ts
+++ b/apps/server/src/fileTransfer.ts
@@ -1,0 +1,142 @@
+import { trzszProtocol } from "./trzszFilter.js";
+
+/**
+ * In-band file transfer: the family of protocols that carry files over the same
+ * byte stream as the shell, because across SSH there is no other channel back to
+ * the machine the human is sitting at.
+ *
+ * They all have the same shape — the remote prints a handshake, the local end
+ * takes over the stream, reads or writes local files, draws a progress bar, then
+ * hands the stream back — and differ only in the bytes. So the terminal side is
+ * written once, here, and each protocol is a plug. Nothing below knows the name
+ * of a command: a transfer begins because the stream said so, not because
+ * someone typed `tsz`.
+ */
+
+/** What the machine the server runs on lends a protocol. */
+export interface TransferHost {
+  /** Straight to the shell: protocol replies, and any command an upload types. */
+  sendToPty(data: string): void;
+  /** Output this filter is done with — the next filter, or the client. */
+  sendToClient(data: string): void;
+  /** Terminal width, for drawing progress bars. */
+  columns: number;
+}
+
+/** One protocol's live state for one session. */
+export interface TransferFilter {
+  /** Shell -> client. Whatever is not this protocol's must reach `sendToClient`. */
+  fromShell(data: string): void;
+  /**
+   * Client -> shell. True means the protocol claimed the keystrokes, which only
+   * happens mid-transfer: there they are cancel signals, and letting them
+   * through would splice user input into the protocol's own byte stream.
+   */
+  fromClient(data: string): boolean;
+  /** Push local paths at the remote without waiting to be asked (drag-and-drop). */
+  startUpload(paths: string[]): Promise<void>;
+  setColumns(cols: number): void;
+}
+
+export interface TransferProtocol {
+  readonly name: string;
+  /**
+   * The handshake as it appears in raw shell output, unanchored and NOT global
+   * — a shared global regex carries a lastIndex between callers. Routing never
+   * uses it (each filter recognizes its own protocol); replayed scrollback does,
+   * because a handshake left in it would announce to a fresh filter a transfer
+   * that ended days ago.
+   */
+  readonly magic: RegExp;
+  /** Can this protocol open a transfer the remote did not ask for? */
+  readonly canInitiateUpload: boolean;
+  create(host: TransferHost): TransferFilter;
+}
+
+/** Every protocol a remote pane speaks, ordered nearest-the-shell first. */
+export const TRANSFER_PROTOCOLS: readonly TransferProtocol[] = [trzszProtocol];
+
+export interface TransferPipeline {
+  fromShell(data: string): void;
+  fromClient(data: string): boolean;
+  startUpload(paths: string[]): Promise<void>;
+  setColumns(cols: number): void;
+  /** False on a pane where no protocol can start an upload — a local shell. */
+  readonly canUpload: boolean;
+}
+
+export interface TransferPipelineOptions {
+  /** Empty for a local shell: nothing to detect, nothing to initiate. */
+  protocols: readonly TransferProtocol[];
+  sendToPty: (data: string) => void;
+  sendToClient: (data: string) => void;
+  columns?: number;
+}
+
+const DEFAULT_COLUMNS = 80;
+
+/**
+ * Chain the protocols between the PTY and the client.
+ *
+ * A chain rather than a dispatcher: each filter already passes through what it
+ * does not recognize, so handing one filter's output to the next needs no
+ * arbitration and no shared notion of who is "active" — which matters because a
+ * handshake is only recognized a beat after the bytes carrying it arrive, and a
+ * dispatcher would have to guess what to do with the stream in between.
+ */
+export function createTransferPipeline(options: TransferPipelineOptions): TransferPipeline {
+  const filters: { protocol: TransferProtocol; filter: TransferFilter }[] = [];
+
+  // Built from the client end backwards, so each filter is handed the one that
+  // comes after it as its own client.
+  let head = options.sendToClient;
+  for (const protocol of [...options.protocols].reverse()) {
+    const next = head;
+    const filter = protocol.create({
+      sendToPty: options.sendToPty,
+      sendToClient: next,
+      columns: options.columns ?? DEFAULT_COLUMNS,
+    });
+    head = (data) => filter.fromShell(data);
+    filters.unshift({ protocol, filter });
+  }
+
+  return {
+    fromShell(data) {
+      head(data);
+    },
+    fromClient(data) {
+      for (const { filter } of filters) {
+        if (filter.fromClient(data)) return true;
+      }
+      return false;
+    },
+    setColumns(cols) {
+      for (const { filter } of filters) filter.setColumns(cols);
+    },
+    get canUpload() {
+      return filters.some(({ protocol }) => protocol.canInitiateUpload);
+    },
+    async startUpload(paths) {
+      const entry = filters.find(({ protocol }) => protocol.canInitiateUpload);
+      if (!entry) throw new Error("no file transfer protocol on this pane");
+      await entry.filter.startUpload(paths);
+    },
+  };
+}
+
+/**
+ * Strip every protocol's handshake from output about to be replayed into a fresh
+ * terminal. Restoring a pane rewrites its scrollback verbatim; a handshake left
+ * in it reads to the new session's filter as a remote asking to transfer, and
+ * pops a dialog for a transfer nobody started.
+ */
+export function stripTransferMagic(data: string): string {
+  let stripped = data;
+  for (const magic of REPLAY_MAGIC) stripped = stripped.replace(magic, "");
+  return stripped;
+}
+
+// String.replace resets a global regex's lastIndex on every call, so these are
+// safe to share; the protocols' own patterns are not, hence the copies.
+const REPLAY_MAGIC = TRANSFER_PROTOCOLS.map((protocol) => new RegExp(protocol.magic.source, "g"));

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -51,6 +51,12 @@ import { testProvider } from "./providerTest.js";
 import { ptyEnvironment } from "./ptyEnvironment.js";
 import { resolveExecutable } from "./shellPath.js";
 import { generateTheme } from "./theme.js";
+import {
+  createTransferPipeline,
+  stripTransferMagic,
+  TRANSFER_PROTOCOLS,
+  type TransferPipeline,
+} from "./fileTransfer.js";
 
 /** Read a JSON request body (capped) into an object. */
 function readJson(req: import("node:http").IncomingMessage, maxChars = 1_000_000): Promise<any> {
@@ -236,7 +242,8 @@ function trackOscCwd(pid: number, data: string): void {
 
 type ClientMessage =
   | { type: "input"; data: string }
-  | { type: "resize"; cols: number; rows: number };
+  | { type: "resize"; cols: number; rows: number }
+  | { type: "upload-files"; paths: string[] };
 
 // Mirrors packages/core's ShellExit wire format — kept in sync by hand because
 // this server bundles standalone (see scripts/bundle-server.mjs) and does not
@@ -302,7 +309,9 @@ function ringAppend(ring: ScrollRing, data: string): void {
  */
 function sanitizeForReplay(data: string): string {
   return (
-    data
+    // File transfer handshakes — replaying one would announce a phantom
+    // transfer to the restored session's pipeline
+    stripTransferMagic(data)
       // DCS strings (XTGETTCAP etc.) — queries wrapped in ESC P ... ESC \
       .replace(/\x1bP[\s\S]*?(?:\x1b\\|\x07)/g, "")
       // OSC 52 — replaying it would overwrite the user's clipboard
@@ -385,6 +394,8 @@ interface PtySession {
   detachedAt: number | null;
   /** Null is the local login shell; otherwise the OpenSSH destination. */
   sshTarget: string | null;
+  /** In-band file transfer, wired in wireSession() as the pty is attached. */
+  transfer?: TransferPipeline;
 }
 
 const ptySessions = new Map<string, PtySession>();
@@ -479,7 +490,9 @@ function wireSession(id: string | undefined, session: PtySession): void {
     if (!shellJob) shellJob = job || (session.sshTarget ? "ssh" : SHELL);
     if (id) activityTracker.noteForegroundJob(id, job, shellJob);
   });
-  session.pty.onData((data) => {
+  /** Everything a client should see: live output, plus the progress bar a
+   *  transfer draws while it runs. Also what history records. */
+  const emit = (data: string) => {
     if (isOpen(session.ws)) session.ws.send(data);
     ringAppend(session.ring, data);
     if (id) {
@@ -487,7 +500,18 @@ function wireSession(id: string | undefined, session: PtySession): void {
       jobSampler.noteOutput();
     }
     if (IS_WIN) trackOscCwd(session.pty.pid, data);
+  };
+  // In-band transfer only makes sense across SSH: it exists to reach the
+  // machine the human is on, which a local shell already is. So a local pane
+  // gets an empty pipeline — a pass-through that cannot be talked into popping
+  // a dialog by a stray handshake in its own output.
+  const transfer = createTransferPipeline({
+    protocols: session.sshTarget ? TRANSFER_PROTOCOLS : [],
+    sendToPty: (data) => session.pty.write(data),
+    sendToClient: emit,
   });
+  session.transfer = transfer;
+  session.pty.onData((data) => transfer.fromShell(data));
   session.pty.onExit(({ exitCode, signal }) => {
     jobSampler.dispose();
     oscCwdByPid.delete(session.pty.pid);
@@ -543,6 +567,28 @@ function killSession(id: string): void {
     /* already gone */
   }
   ptySessions.delete(id);
+}
+
+/**
+ * Drag-and-drop upload, driven by paths the webview harvested from a native OS
+ * file drop. Which protocol carries it, and whatever command it has to type to
+ * get the remote's attention, is the pipeline's business. Only remote panes
+ * have a protocol to offer, so a local one gets a visible refusal instead of a
+ * meaningless local path pasted into the shell.
+ */
+function runUpload(session: PtySession, paths: string[]): void {
+  if (!session.transfer?.canUpload) {
+    if (isOpen(session.ws)) {
+      session.ws.send("\r\n\x1b[31m[termany] file upload is only available on remote (SSH) panes\x1b[0m\r\n");
+    }
+    return;
+  }
+  void session.transfer.startUpload(paths).catch((err) => {
+    const message = err instanceof Error ? err.message : String(err);
+    if (isOpen(session.ws)) {
+      session.ws.send(`\r\n\x1b[31m[termany] upload failed: ${message}\x1b[0m\r\n`);
+    }
+  });
 }
 
 // Safety net: a shell detached (app closed, never reopened) longer than this
@@ -1744,7 +1790,7 @@ wss.on("connection", async (ws: WebSocket, req) => {
       }
       if (msg.type === "input") {
         activityTracker.noteInput(sessionId!, msg.data, agent);
-        existing.pty.write(msg.data);
+        if (!existing.transfer?.fromClient(msg.data)) existing.pty.write(msg.data);
       }
       else if (msg.type === "resize") {
         try {
@@ -1752,6 +1798,10 @@ wss.on("connection", async (ws: WebSocket, req) => {
         } catch {
           /* race during teardown */
         }
+        existing.transfer?.setColumns(Math.max(1, msg.cols));
+      }
+      else if (msg.type === "upload-files") {
+        runUpload(existing, msg.paths);
       }
     });
     ws.on("close", () => {
@@ -1790,13 +1840,16 @@ wss.on("connection", async (ws: WebSocket, req) => {
     }
     if (msg.type === "input") {
       if (sessionId) activityTracker.noteInput(sessionId, msg.data, agent);
-      session.pty.write(msg.data);
+      if (!session.transfer?.fromClient(msg.data)) session.pty.write(msg.data);
     } else if (msg.type === "resize") {
       try {
         session.pty.resize(Math.max(1, msg.cols), Math.max(1, msg.rows));
       } catch {
         /* race during teardown */
       }
+      session.transfer?.setColumns(Math.max(1, msg.cols));
+    } else if (msg.type === "upload-files") {
+      runUpload(session, msg.paths);
     }
   };
 

--- a/apps/server/src/trzszFilter.test.ts
+++ b/apps/server/src/trzszFilter.test.ts
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { inflateSync } from "node:zlib";
+import { createTrzszFilter, trzszProtocol } from "./trzszFilter.js";
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** A filter whose pickers always cancel, recording both wire directions. */
+function recorder() {
+  const toPty: string[] = [];
+  const toClient: string[] = [];
+  return {
+    toPty,
+    toClient,
+    filter: createTrzszFilter(
+      {
+        sendToPty: (data) => toPty.push(data),
+        sendToClient: (data) => toClient.push(data),
+        columns: 80,
+      },
+      {
+        chooseSendFiles: async () => undefined,
+        chooseSaveDirectory: async () => undefined,
+        dragInitTimeout: 100,
+      }
+    ),
+  };
+}
+
+const MAGIC_DOWNLOAD = "\x1b7\x07::TRZSZ:TRANSFER:S:1.2.3:0000000000001\r\n";
+const MAGIC_UPLOAD = "\x1b7\x07::TRZSZ:TRANSFER:R:1.2.3:0000000000002\r\n";
+
+/** Decode the `#ACT:<base64>` reply (zlib + base64) the filter sends. */
+function decodeAction(toPty: string[]) {
+  const line = toPty.find((data) => data.startsWith("#ACT:"));
+  assert.ok(line, "expected an #ACT reply");
+  const json = inflateSync(Buffer.from(line!.slice(5), "base64")).toString("utf8");
+  return JSON.parse(json) as { confirm?: boolean };
+}
+
+test("passes ordinary output through untouched", () => {
+  const r = recorder();
+  r.filter.fromShell("hello\r\n");
+  assert.deepEqual(r.toClient, ["hello\r\n"]);
+  assert.deepEqual(r.toPty, []);
+});
+
+test("leaves ordinary input to the shell", () => {
+  const r = recorder();
+  // Idle, the protocol claims nothing — the pipeline writes the keystrokes.
+  assert.equal(r.filter.fromClient("ls\r"), false);
+  assert.deepEqual(r.toPty, []);
+});
+
+test("download magic key takes over and refuses politely when the dialog is canceled", async () => {
+  const r = recorder();
+  r.filter.fromShell("tsz some-file.txt\r\n");
+  r.filter.fromShell(MAGIC_DOWNLOAD);
+  await sleep(80);
+  // A canceled save dialog still answers the handshake, with confirm=false.
+  assert.equal(decodeAction(r.toPty).confirm, false);
+  // The transfer is over; the stream is transparent again.
+  r.filter.fromShell("back to normal\r\n");
+  assert.ok(r.toClient.includes("back to normal\r\n"));
+});
+
+test("upload magic key takes over and refuses politely when the dialog is canceled", async () => {
+  const r = recorder();
+  r.filter.fromShell("trz\r\n");
+  r.filter.fromShell(MAGIC_UPLOAD);
+  await sleep(80);
+  assert.equal(decodeAction(r.toPty).confirm, false);
+});
+
+test("startUpload types the trz command and feeds the picked paths", async () => {
+  const r = recorder();
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "termany-trzsz-"));
+  const file = path.join(dir, "hello.txt");
+  fs.writeFileSync(file, "hello");
+  try {
+    // The filter resolves the paths against the filesystem before typing, and
+    // the promise later rejects with "Upload does not start" (no remote peer
+    // in this test) — neither is what this test is about.
+    r.filter.startUpload([file]).catch(() => {});
+    await sleep(300);
+    assert.ok(r.toPty.includes("\x03"));
+    assert.ok(r.toPty.some((data) => data.endsWith("trz\r")));
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("the protocol's magic matches the handshake it takes over on", () => {
+  assert.match(MAGIC_DOWNLOAD, trzszProtocol.magic);
+  assert.match(MAGIC_UPLOAD, trzszProtocol.magic);
+});

--- a/apps/server/src/trzszFilter.ts
+++ b/apps/server/src/trzszFilter.ts
@@ -1,0 +1,86 @@
+import { pickFiles } from "./filePicker.js";
+import { pickFolder } from "./folderPicker.js";
+import type { TransferFilter, TransferHost, TransferProtocol } from "./fileTransfer.js";
+
+// The `trzsz` package ships a UMD/CJS bundle whose exports are assigned
+// dynamically, so ESM named imports fail under Node ("does not provide an
+// export named 'TrzszFilter'"). A default import reaches the same object and
+// also lets esbuild inline the package into the bundled server — a runtime
+// createRequire would be left as a dynamic require the packaged app cannot
+// satisfy.
+import trzszPackage from "trzsz";
+
+const TrzszFilterImpl = (trzszPackage as typeof import("trzsz")).TrzszFilter;
+
+/** Test seams: the native dialogs and the drag-upload deadline. */
+export interface TrzszOverrides {
+  chooseSendFiles?: (directory?: boolean) => Promise<string[] | undefined>;
+  chooseSaveDirectory?: () => Promise<string | undefined>;
+  /** How long a drag-drop upload waits for the remote to start (ms). */
+  dragInitTimeout?: number;
+}
+
+/**
+ * trzsz (`trz` / `tsz`) as a transfer protocol plug.
+ *
+ * The server already sits on the byte path between the SSH session and the
+ * webview, and it has what the browser webview lacks: the local filesystem and
+ * OS-native pickers. The filter stays transparent until a remote `trz`/`tsz`
+ * prints the `::TRZSZ:TRANSFER:` handshake, then takes over the stream, resolves
+ * file selection through native dialogs, and renders the progress bar back into
+ * the terminal.
+ *
+ * Text/base64 mode only: the PTY<->WebSocket pipeline is a UTF-8 text channel,
+ * so remote `-b` binary mode would corrupt non-ASCII bytes.
+ */
+export const trzszProtocol: TransferProtocol = {
+  name: "trzsz",
+  magic: /\x1b7\x07::TRZSZ:TRANSFER:[SRD]:[\d.]+(?::\d+)?\r?\n/,
+  canInitiateUpload: true,
+  create: (host) => createTrzszFilter(host),
+};
+
+export function createTrzszFilter(host: TransferHost, overrides: TrzszOverrides = {}): TransferFilter {
+  const filter = new TrzszFilterImpl({
+    writeToTerminal: (data) => {
+      host.sendToClient(typeof data === "string" ? data : Buffer.from(data as Uint8Array).toString("utf8"));
+    },
+    sendToServer: (data) => {
+      host.sendToPty(typeof data === "string" ? data : Buffer.from(data).toString("utf8"));
+    },
+    chooseSendFiles:
+      overrides.chooseSendFiles ??
+      (async (directory) => {
+        if (directory) {
+          const dir = await pickFolder("Select the directory to upload");
+          return dir ? [dir] : undefined;
+        }
+        return (await pickFiles("Select files to upload")) ?? undefined;
+      }),
+    chooseSaveDirectory:
+      overrides.chooseSaveDirectory ??
+      (async () => {
+        return (await pickFolder("Select where to save the downloaded files")) ?? undefined;
+      }),
+    terminalColumns: host.columns,
+    isWindowsShell: process.platform === "win32",
+    dragInitTimeout: overrides.dragInitTimeout,
+  });
+
+  return {
+    fromShell: (data) => filter.processServerOutput(data),
+    fromClient: (data) => {
+      // Idle, the shell owns the keyboard and the pipeline writes the bytes
+      // through. Mid-transfer trzsz reads them as its own control channel:
+      // Ctrl-C stops the transfer, everything else is discarded rather than
+      // spliced into the protocol stream.
+      if (!filter.isTransferringFiles()) return false;
+      filter.processTerminalInput(data);
+      return true;
+    },
+    startUpload: async (paths) => {
+      await filter.uploadFiles(paths);
+    },
+    setColumns: (cols) => filter.setTerminalColumns(cols),
+  };
+}

--- a/apps/web/src/clipboard.ts
+++ b/apps/web/src/clipboard.ts
@@ -1,0 +1,57 @@
+/**
+ * Write text to the system clipboard, from anywhere in the app.
+ *
+ * The async Clipboard API is the good path, and it covers the desktop build too
+ * (Tauri serves the UI from a secure context), but it is not always available:
+ * a plain-http deployment is not a secure context, and WKWebView can reject a
+ * write that isn't tied to a user gesture — which is exactly the OSC 52 case,
+ * where a remote program, not a click, asks for the copy. So keep the legacy
+ * `execCommand` path as a fallback rather than losing the copy silently.
+ *
+ * Returns whether the text actually made it, so a caller can report a dead copy
+ * instead of leaving the user wondering.
+ */
+export async function writeClipboard(text: string): Promise<boolean> {
+  if (window.isSecureContext && navigator.clipboard) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Permission denied / no user gesture — fall through.
+    }
+  }
+  return copyViaTextarea(text);
+}
+
+/**
+ * `document.execCommand("copy")` needs the text selected in a live DOM node, so
+ * borrow focus for one synchronous moment and give it straight back.
+ *
+ * Restoring focus is not cosmetic: the terminal reads keystrokes through a
+ * focused textarea of its own, so leaving focus here would silently swallow the
+ * user's typing, and stealing it mid-composition can break the WebKit IME
+ * sequencing that webkitGtkIme.ts/imeGuard.ts work around. The node also stays
+ * out of `.term-host` and is `readOnly` so xterm never sees it as its own.
+ */
+function copyViaTextarea(text: string): boolean {
+  const previous = document.activeElement;
+  const ta = document.createElement("textarea");
+  ta.value = text;
+  ta.readOnly = true;
+  ta.setAttribute("aria-hidden", "true");
+  // Off-screen rather than `display: none` / `opacity: 0` — an unrendered node
+  // cannot hold a selection, which is what execCommand copies from.
+  ta.style.position = "fixed";
+  ta.style.top = "-9999px";
+  ta.style.left = "-9999px";
+  document.body.appendChild(ta);
+  try {
+    ta.select();
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    ta.remove();
+    if (previous instanceof HTMLElement) previous.focus({ preventScroll: true });
+  }
+}

--- a/apps/web/src/components/TerminalPane.tsx
+++ b/apps/web/src/components/TerminalPane.tsx
@@ -10,6 +10,7 @@ import {
   subscribeTerminalScrollState,
   subscribeSshNaturalExit,
   terminalSessionId,
+  uploadFilesToSession,
   type TerminalScrollState,
 } from "../terminal/manager";
 import { subscribeDesktopFileDrops } from "../terminal/desktopFileDrop";
@@ -170,13 +171,17 @@ export function TerminalPane({ id, sshTarget }: { id: string; sshTarget?: string
 
       if (event.type === "drop") {
         setDragOver(false);
-        void openLocalPathsInSession(id, event.paths);
+        if (sshTarget && event.paths.length) {
+          uploadFilesToSession(terminalSessionId(id, sshTarget), event.paths);
+        } else {
+          void openLocalPathsInSession(id, event.paths);
+        }
         return;
       }
 
       setDragOver(true);
     });
-  }, [id]);
+  }, [id, sshTarget]);
 
   return (
     <div className={`term-pane ${dragOver ? "drag-over" : ""}`}>
@@ -198,7 +203,11 @@ export function TerminalPane({ id, sshTarget }: { id: string; sshTarget?: string
           e.preventDefault();
           setDragOver(false);
           const paths = extractDroppedPaths(e.dataTransfer);
-          void openLocalPathsInSession(id, paths);
+          if (sshTarget && paths.length) {
+            uploadFilesToSession(terminalSessionId(id, sshTarget), paths);
+          } else {
+            void openLocalPathsInSession(id, paths);
+          }
         }}
       />
       {scrollState.hasOverflow && (

--- a/apps/web/src/demo.ts
+++ b/apps/web/src/demo.ts
@@ -148,6 +148,10 @@ export class DemoBackend implements ITerminalBackend {
     /* the demo session never ends */
   }
 
+  uploadFiles(_paths: string[]): void {
+    /* the demo shell has no remote side to upload to */
+  }
+
   resize(_cols: number, _rows: number): void {
     /* nothing to tell — there is no PTY */
   }

--- a/apps/web/src/terminal/manager.ts
+++ b/apps/web/src/terminal/manager.ts
@@ -71,6 +71,8 @@ export interface Session {
   connectionState?: "connecting" | "connected" | "disconnected";
   /** Increments for every PTY output chunk, including in-place TUI redraws. */
   contentVersion: number;
+  /** Set when this session's shell is an OpenSSH destination. */
+  sshTarget?: string;
 }
 
 /**
@@ -1479,6 +1481,7 @@ function getSession(id: string, cwdFrom?: string[], sshTarget?: string, paneId =
     ended: false,
     connectionState: sshTarget ? "connecting" : undefined,
     contentVersion: 0,
+    sshTarget,
   };
   sessions.set(id, session);
   refreshOnSymbolsFontLoad();
@@ -2109,6 +2112,17 @@ export function queueCommand(id: string, command: string) {
 export function pasteIntoSession(id: string, text: string) {
   id = activeSessionId(id);
   sessions.get(id)?.term.paste(text);
+}
+
+/**
+ * Hand local paths to the active session's backend to upload. The server picks
+ * the transfer protocol and only honors this on SSH sessions; local panes show
+ * a refusal line instead of swallowing the drop.
+ */
+export function uploadFilesToSession(id: string, paths: string[]) {
+  id = activeSessionId(id);
+  if (!paths.length) return;
+  sessions.get(id)?.backend.uploadFiles(paths);
 }
 
 export function sessionUsesAlternateBuffer(id: string): boolean {

--- a/apps/web/src/terminal/manager.ts
+++ b/apps/web/src/terminal/manager.ts
@@ -8,6 +8,7 @@ import { Terminal, type ITheme } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
 import { loadAgentConfigs } from "../agents";
 import { apiUrl } from "../api";
+import { writeClipboard } from "../clipboard";
 import { DemoBackend, demoInteracted, isDemo } from "../demo";
 import { ACTIONS, loadKeybindings, matchChord } from "../keybindings";
 import {
@@ -22,6 +23,7 @@ import {
 } from "./agentIdleWatcher";
 import { SYMBOLS_FONT_FAMILY, withSymbolsFallback } from "./fonts";
 import { registerLocalPathLinks } from "./localLinks";
+import { registerOsc52 } from "./osc52";
 import {
   MAX_AUTO_RESTARTS,
   RESTART_HEALTHY_MS,
@@ -1420,6 +1422,9 @@ function getSession(id: string, cwdFrom?: string[], sshTarget?: string, paneId =
   // Make URLs open on Cmd+click. The custom provider also joins links hard-
   // wrapped by rich CLI output, which xterm's stock addon cannot do.
   registerWebLinks(term);
+  // Let programs copy to the local clipboard via OSC 52 — the only copy channel
+  // that survives SSH, and how agent CLIs expect "copy" to work. Write-only.
+  registerOsc52(term);
   // Local file paths (including relative ones like `src/foo.ts`) are verified
   // and resolved by the server against this shell's live cwd. If the server
   // can't answer (demo mode, old server), fall back to trusting absolute
@@ -1609,7 +1614,7 @@ function getSession(id: string, cwdFrom?: string[], sshTarget?: string, paneId =
     const sel = term.getSelection();
     // Use trim only as an emptiness check. Copy the original selection so
     // meaningful indentation and line breaks are preserved.
-    if (sel.trim()) navigator.clipboard?.writeText(sel).catch(() => {});
+    if (sel.trim()) void writeClipboard(sel);
   });
 
   // Paste image blobs as local file paths only when the active program looks

--- a/apps/web/src/terminal/osc52.test.ts
+++ b/apps/web/src/terminal/osc52.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { Terminal } from "@xterm/xterm";
+import { handleOsc52, registerOsc52 } from "./osc52";
+
+/** Collects clipboard writes instead of performing them. */
+function recorder(ok = true) {
+  const writes: string[] = [];
+  return {
+    writes,
+    write: async (text: string) => {
+      writes.push(text);
+      return ok;
+    },
+  };
+}
+
+const b64 = (text: string) => Buffer.from(text, "utf8").toString("base64");
+
+/** Let the un-awaited clipboard write inside the handler settle. */
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+test("registers on ident 52 and copies through the terminal's parser", async () => {
+  const clip = recorder();
+  let registered: number | undefined;
+  let handler: ((data: string) => boolean | Promise<boolean>) | undefined;
+  const term = {
+    parser: {
+      registerOscHandler(ident: number, callback: (data: string) => boolean | Promise<boolean>) {
+        registered = ident;
+        handler = callback;
+        return { dispose() {} };
+      },
+    },
+  } as unknown as Terminal;
+
+  registerOsc52(term, clip.write);
+  assert.equal(registered, 52);
+
+  // The payload xterm actually delivers: it strips `ESC ] 52 ;` and nothing
+  // more, so the selection target is still attached. A handler that assumed a
+  // bare base64 string here would throw on every real-world sequence.
+  assert.equal(await handler!(`c;${b64("hello")}`), true);
+  await flush();
+  assert.deepEqual(clip.writes, ["hello"]);
+});
+
+test("decodes UTF-8 rather than mangling multi-byte characters", async () => {
+  const clip = recorder();
+  assert.equal(handleOsc52(`c;${b64("你好")}`, clip.write), true);
+  await flush();
+  assert.deepEqual(clip.writes, ["你好"]);
+});
+
+test("accepts the other clipboard selection targets, skips PRIMARY-only", async () => {
+  for (const target of ["c", "s", "", "cs"]) {
+    const clip = recorder();
+    assert.equal(handleOsc52(`${target};${b64("x")}`, clip.write), true, target);
+    await flush();
+    assert.deepEqual(clip.writes, ["x"], target);
+  }
+
+  // X11 PRIMARY has no browser equivalent; copying it would hijack ⌘V.
+  const primary = recorder();
+  assert.equal(handleOsc52(`p;${b64("x")}`, primary.write), false);
+  await flush();
+  assert.deepEqual(primary.writes, []);
+});
+
+test("refuses read requests so a program cannot steal the clipboard", async () => {
+  const clip = recorder();
+  assert.equal(handleOsc52("c;?", clip.write), false);
+  await flush();
+  assert.deepEqual(clip.writes, []);
+});
+
+test("leaves the clipboard untouched on invalid base64", async () => {
+  const clip = recorder();
+  for (const body of ["!!!not-base64!!!", "aGVsbG8", "a===", "你好"]) {
+    assert.equal(handleOsc52(`c;${body}`, clip.write), false, body);
+  }
+  await flush();
+  assert.deepEqual(clip.writes, []);
+});
+
+test("treats an empty payload as handled but never clears the clipboard", async () => {
+  const clip = recorder();
+  assert.equal(handleOsc52("c;", clip.write), true);
+  await flush();
+  assert.deepEqual(clip.writes, []);
+});
+
+test("ignores a malformed sequence with no selection target", async () => {
+  const clip = recorder();
+  assert.equal(handleOsc52(b64("hello"), clip.write), false);
+  await flush();
+  assert.deepEqual(clip.writes, []);
+});
+
+test("tolerates whitespace-wrapped base64 from the emitting side", async () => {
+  const clip = recorder();
+  const wrapped = b64("a longer copy payload that a writer might hard-wrap")
+    .replace(/(.{16})/g, "$1\n");
+  assert.equal(handleOsc52(`c;${wrapped}`, clip.write), true);
+  await flush();
+  assert.deepEqual(clip.writes, ["a longer copy payload that a writer might hard-wrap"]);
+});
+
+test("refuses an oversized payload instead of flooding the clipboard", async () => {
+  const clip = recorder();
+  assert.equal(handleOsc52(`c;${"A".repeat(1_400_004)}`, clip.write), false);
+  await flush();
+  assert.deepEqual(clip.writes, []);
+});
+
+test("reports a blocked clipboard write without throwing", async () => {
+  const clip = recorder(false);
+  const warnings: unknown[] = [];
+  const original = console.warn;
+  console.warn = (...args: unknown[]) => warnings.push(args[0]);
+  try {
+    assert.equal(handleOsc52(`c;${b64("hi")}`, clip.write), true);
+    await flush();
+  } finally {
+    console.warn = original;
+  }
+  assert.deepEqual(clip.writes, ["hi"]);
+  assert.equal(warnings.length, 1);
+});

--- a/apps/web/src/terminal/osc52.ts
+++ b/apps/web/src/terminal/osc52.ts
@@ -1,0 +1,89 @@
+import type { Terminal } from "@xterm/xterm";
+import { writeClipboard } from "../clipboard";
+
+/**
+ * OSC 52 — "Manipulate Selection Data", how a program tells its terminal to put
+ * something on the clipboard: `ESC ] 52 ; c ; <base64> BEL`.
+ *
+ * This is the sequence Claude Code and friends emit when they copy, and it is
+ * the only copy channel that survives SSH — the program has no other way to
+ * reach the machine the human is sitting at. xterm.js parses OSC 52 and then
+ * drops it (it ships handlers for the title/colour idents, but none for 52), so
+ * without this the copy silently disappears at the terminal.
+ *
+ * Writes only. The read form (`52;c;?`) asks the terminal to hand the clipboard
+ * back to the program, which for a terminal hosting semi-autonomous agents is a
+ * straight exfiltration path for whatever the user last copied — a password, a
+ * key — so it is refused. Returning `false` leaves the sequence unhandled and,
+ * with no other handler registered for 52, nothing replies.
+ */
+
+/** Selection targets that mean "the clipboard the user pastes from". `s` is the
+ *  ambiguous "whichever is configured"; browsers expose only the one. A `p`-only
+ *  (X11 PRIMARY) request has no browser equivalent, so it is left alone rather
+ *  than hijacking ⌘V. An empty target — which the spec defaults to `s0` — passes
+ *  the check below vacuously, there being no character to reject. */
+const CLIPBOARD_TARGETS = ["c", "s"];
+
+/** Base64 of ~1 MB of text. xterm tolerates 10 MB OSC payloads; a copy that
+ *  large is a runaway program, not a user action, and the clipboard is the
+ *  user's, so refuse rather than let it be flooded. */
+const MAX_BASE64_LENGTH = 1_400_000;
+
+const BASE64_RE = /^[A-Za-z0-9+/]*={0,2}$/;
+
+type WriteClipboard = (text: string) => Promise<boolean>;
+
+/** Register the handler on one Terminal. Call once per instance; it is disposed
+ *  along with the terminal. `write` is injectable for tests. */
+export function registerOsc52(term: Terminal, write: WriteClipboard = writeClipboard): void {
+  term.parser.registerOscHandler(52, (data) => handleOsc52(data, write));
+}
+
+/**
+ * `data` is everything after `ESC ] 52 ;` — xterm strips the ident and the ONE
+ * semicolon that follows it, so this still receives the selection target:
+ * `"c;aGVsbG8="`, not `"aGVsbG8="`. Splitting it off is what makes the decode
+ * work at all; `atob` on the raw argument would throw on every well-formed
+ * sequence, and a `?` read check would never match.
+ */
+export function handleOsc52(data: string, write: WriteClipboard): boolean {
+  const semi = data.indexOf(";");
+  if (semi < 0) return false;
+  const target = data.slice(0, semi);
+  const body = data.slice(semi + 1);
+
+  // Read request — never answered. See the note above.
+  if (body === "?") return false;
+
+  if (![...target].every((t) => CLIPBOARD_TARGETS.includes(t))) return false;
+
+  // An empty payload is a request to CLEAR the clipboard. Treat it as handled
+  // but do nothing: a background agent wiping what the user just copied is all
+  // cost and no benefit.
+  if (body === "") return true;
+
+  if (body.length > MAX_BASE64_LENGTH) return false;
+
+  // Long payloads are often hard-wrapped by the emitting side.
+  const base64 = body.replace(/\s+/g, "");
+  if (base64.length % 4 !== 0 || !BASE64_RE.test(base64)) return false;
+
+  let text: string;
+  try {
+    // Two steps on purpose: atob yields one char per BYTE, so using its result
+    // directly renders any multi-byte character as mojibake ("你好" as "ä½ å¥½").
+    // Reassemble the bytes and decode them as UTF-8.
+    const bytes = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
+    text = new TextDecoder("utf-8").decode(bytes);
+  } catch {
+    return false; // Not valid base64 after all — leave the clipboard untouched.
+  }
+
+  // Deliberately not awaited: the parser would hold up ALL terminal output
+  // until the clipboard settled, and this runs on the render hot path.
+  void write(text).then((ok) => {
+    if (!ok) console.warn("[termany] OSC 52: clipboard write was blocked");
+  });
+  return true;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@agentclientprotocol/sdk": "^1.2.1",
         "@anthropic-ai/sdk": "^0.106.0",
         "node-pty": "^1.0.0",
+        "trzsz": "^1.1.6",
         "undici": "^8.5.0",
         "ws": "^8.18.0"
       },
@@ -3413,6 +3414,16 @@
       "license": "MIT",
       "bin": {
         "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/trzsz": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/trzsz/-/trzsz-1.1.6.tgz",
+      "integrity": "sha512-UkUk7xQ96ZNWhmkpqDJxAzi2Zk52siPdHlitI+JtxwpEpYTR98KK/j0CoVrk3DWoLXeFqxNutSeUIOVzP1Eosg==",
+      "license": "MIT",
+      "bin": {
+        "trz": "bin/trz.js",
+        "tsz": "bin/tsz.js"
       }
     },
     "node_modules/ts-algebra": {

--- a/packages/core/src/backend.ts
+++ b/packages/core/src/backend.ts
@@ -15,6 +15,8 @@ export interface ITerminalBackend {
   onData(cb: (data: string) => void): void;
   /** Send user keystrokes / input to the shell (UI -> server). */
   write(data: string): void;
+  /** Ask the session to upload local paths to the remote (SSH panes). */
+  uploadFiles(paths: string[]): void;
   /** Tell the PTY the new viewport size. */
   resize(cols: number, rows: number): void;
   /**
@@ -30,7 +32,8 @@ export interface ITerminalBackend {
 /** Wire protocol: UI -> server messages (JSON text frames). */
 export type ClientMessage =
   | { type: "input"; data: string }
-  | { type: "resize"; cols: number; rows: number };
+  | { type: "resize"; cols: number; rows: number }
+  | { type: "upload-files"; paths: string[] };
 
 /**
  * How a shell process ended, as observed by the PTY host.

--- a/packages/core/src/ws-backend.ts
+++ b/packages/core/src/ws-backend.ts
@@ -80,6 +80,10 @@ export class WebSocketBackend implements ITerminalBackend {
     this.send({ type: "input", data });
   }
 
+  uploadFiles(paths: string[]) {
+    this.send({ type: "upload-files", paths });
+  }
+
   resize(cols: number, rows: number) {
     this.send({ type: "resize", cols, rows });
   }


### PR DESCRIPTION
## Summary
- **OSC 52 (write-only):** remote programs can copy to the local clipboard over SSH. xterm.js parses ident 52 and drops it; a handler now decodes the payload and writes it. The read form (`52;c;?`) is refused so a remote process cannot exfiltrate the clipboard. Selection copy shares the same `writeClipboard` path (Clipboard API, with a textarea/`execCommand` fallback).
- **In-band file transfer:** SSH panes carry files over the PTY byte stream. The PTY server sits on that path and has the local filesystem plus OS-native pickers, so remote `trz`/`tsz` pop a native dialog, stream through the existing protocol, and draw a progress bar back into the terminal. No SFTP and no separate file manager.
- **Protocol layer, not a trzsz-only hook:** `fileTransfer.ts` owns the terminal side once (host I/O, filter chaining, replay sanitization). A protocol is a plug — trzsz is the first; ZMODEM or SFTP would be another. Drag-and-drop on an SSH pane sends `upload-files`; which protocol carries it is the pipeline's business. Local panes get an empty pipeline so a stray handshake cannot pop a dialog.

## Test plan
- [ ] SSH pane: a remote program that emits OSC 52 (e.g. `printf '\e]52;c;%s\a' "$(printf hello | base64)"`) puts `hello` on the local clipboard
- [ ] OSC 52 read requests (`52;c;?`) do not reply with clipboard contents
- [ ] SSH pane: `tsz some-file.txt` opens a native save-directory dialog; canceling refuses the handshake cleanly; accepting saves the file locally with a progress bar in the terminal
- [ ] SSH pane: `trz` opens a native file picker; selected files upload; canceling refuses cleanly
- [ ] Drag files onto an SSH pane uploads them (types `trz` / `trz -d` itself); drag onto a local pane still pastes/opens paths as before
- [ ] Mid-transfer Ctrl-C stops the transfer; other keystrokes are not spliced into the protocol stream
- [ ] Restore an SSH pane whose history contains a `::TRZSZ:TRANSFER:` handshake — no phantom file dialog
- [ ] Local (non-SSH) pane: no file-transfer dialogs; ordinary output and input unchanged
- [ ] `npm -w @termany/server run test` and `npm -w @termany/web run test` pass

Made with [Cursor](https://cursor.com)